### PR TITLE
Fix Age Range Filter Bug

### DIFF
--- a/fhir-backend-dynamic/app/routers/resources.py
+++ b/fhir-backend-dynamic/app/routers/resources.py
@@ -339,19 +339,29 @@ def process_search_parameters(query_params: Dict[str, str], resource_type: str) 
                 processed["_has"] = f"Condition:patient:code={condition_code}"
         elif key == "age_min" and resource_type.lower() == "patient":
             # Handle minimum age filtering - convert to FHIR birthdate parameter
+            # Use list to accumulate multiple birthdate constraints
             if value and value.strip() and value.isdigit():
                 from datetime import datetime
                 current_year = datetime.now().year
                 birth_year = current_year - int(value)
-                processed["birthdate"] = f"le{birth_year}-12-31"
+                if "birthdate" not in processed:
+                    processed["birthdate"] = []
+                elif isinstance(processed["birthdate"], str):
+                    processed["birthdate"] = [processed["birthdate"]]
+                processed["birthdate"].append(f"le{birth_year}-12-31")
                 logger.info(f"Age filter: min age {value} -> birthdate le{birth_year}-12-31")
         elif key == "age_max" and resource_type.lower() == "patient":
             # Handle maximum age filtering - convert to FHIR birthdate parameter
+            # Use list to accumulate multiple birthdate constraints
             if value and value.strip() and value.isdigit():
                 from datetime import datetime
                 current_year = datetime.now().year
                 birth_year = current_year - int(value)
-                processed["birthdate"] = f"ge{birth_year}-01-01"
+                if "birthdate" not in processed:
+                    processed["birthdate"] = []
+                elif isinstance(processed["birthdate"], str):
+                    processed["birthdate"] = [processed["birthdate"]]
+                processed["birthdate"].append(f"ge{birth_year}-01-01")
                 logger.info(f"Age filter: max age {value} -> birthdate ge{birth_year}-01-01")
         elif key == "gender" and resource_type.lower() == "patient":
             # Handle gender filtering - direct FHIR parameter
@@ -709,22 +719,26 @@ async def search_patients_by_condition(
         }
         
         # Add age filtering via birthdate
+        # Use list for multiple birthdate constraints - FHIR requires separate query parameters
         if age_min is not None or age_max is not None:
             current_year = datetime.now().year
+            birthdate_constraints = []
             
-            if age_min is not None and age_max is not None:
-                # Age range
+            if age_max is not None:
+                # Maximum age means minimum birth year (born after this date)
                 min_birth_year = current_year - age_max
+                birthdate_constraints.append(f"ge{min_birth_year}-01-01")
+            
+            if age_min is not None:
+                # Minimum age means maximum birth year (born before this date)
                 max_birth_year = current_year - age_min
-                params["birthdate"] = f"ge{min_birth_year}-01-01&birthdate=le{max_birth_year}-12-31"
-            elif age_min is not None:
-                # Only minimum age
-                max_birth_year = current_year - age_min
-                params["birthdate"] = f"le{max_birth_year}-12-31"
-            elif age_max is not None:
-                # Only maximum age
-                min_birth_year = current_year - age_max
-                params["birthdate"] = f"ge{min_birth_year}-01-01"
+                birthdate_constraints.append(f"le{max_birth_year}-12-31")
+            
+            # Store as list for proper multi-value parameter handling
+            if len(birthdate_constraints) == 1:
+                params["birthdate"] = birthdate_constraints[0]
+            else:
+                params["birthdate"] = birthdate_constraints
         
         # Add gender filtering
         if gender:


### PR DESCRIPTION
Fixes #13
## Summary
Fixes a critical bug where providing both `age_min` and `age_max` query parameters resulted in only one constraint being applied, returning incorrect patient populations.

## Problem

### Bug 1: `process_search_parameters()` Overwrites Birthdate
When both age parameters were provided, the second one silently overwrote the first:

```python
# BEFORE (broken)
elif key == "age_min":
    processed["birthdate"] = f"le{birth_year}-12-31"   # ← set once

elif key == "age_max":
    processed["birthdate"] = f"ge{birth_year}-01-01"   # ← OVERWRITES
```

Since Python dict keys are unique, only the last-processed age filter took effect.

### Bug 2: `search_patients_by_condition()` String Concatenation
The endpoint embedded a literal `&birthdate=` inside a query parameter value:

```python
# BEFORE (broken)
params["birthdate"] = f"ge{min_birth_year}-01-01&birthdate=le{max_birth_year}-12-31"
```

This failed on FHIR servers because `&birthdate=` became part of the value string rather than a separate parameter.

## Solution

### Fix 1: List-Based Accumulation
Changed `process_search_parameters()` to accumulate birthdate constraints as a list:

```python
# AFTER (fixed)
if "birthdate" not in processed:
    processed["birthdate"] = []
elif isinstance(processed["birthdate"], str):
    processed["birthdate"] = [processed["birthdate"]]
processed["birthdate"].append(f"le{birth_year}-12-31")
```

### Fix 2: Proper Multi-Value Parameters
Changed `search_patients_by_condition()` to use list-based parameters:

```python
# AFTER (fixed)
birthdate_constraints = []
if age_max is not None:
    birthdate_constraints.append(f"ge{min_birth_year}-01-01")
if age_min is not None:
    birthdate_constraints.append(f"le{max_birth_year}-12-31")

if len(birthdate_constraints) == 1:
    params["birthdate"] = birthdate_constraints[0]
else:
    params["birthdate"] = birthdate_constraints
```

### Why This Works
`httpx` natively handles list values for query parameters:
- Input: `{"birthdate": ["ge1960-01-01", "le2008-12-31"]}`
- Output URL: `?birthdate=ge1960-01-01&birthdate=le2008-12-31`

This is exactly what FHIR servers expect for multi-value search parameters.


## Testing

### Manual Validation
1. Test against HAPI FHIR server: `https://hapi.fhir.org/baseR4`
2. Query: `GET /api/resources/Patient?age_min=18&age_max=65`
3. Verify backend logs show both birthdate parameters sent as separate query params
4. Verify returned patients fall within expected birth year range

### Test Cases
| Scenario | Expected Behavior |
|----------|-------------------|
| Only `age_min=18` | `birthdate=le{year-18}-12-31` |
| Only `age_max=65` | `birthdate=ge{year-65}-01-01` |
| Both `age_min=18&age_max=65` | `birthdate=ge{year-65}-01-01&birthdate=le{year-18}-12-31` |
| Edge case: `age_min=0` | Should work (newborns) |
| Edge case: `age_max=150` | Should work (upper bound) |