### PR TITLE
Fix Quantity Unit Display Bug

### DIFF
--- a/src/DynamicResourceTab.js
+++ b/src/DynamicResourceTab.js
@@ -131,7 +131,29 @@ const DynamicResourceTab = ({
         return value.code;
       }
       
-      // Handle nested values
+      // Handle quantity objects with units (must check BEFORE generic .value extraction)
+      if (value.value !== undefined && value.unit) {
+        return <span>
+          <strong>{value.value}</strong> {value.unit}
+        </span>;
+      }
+      
+      // Handle quantity with comparator (e.g., "< 5 mg/dL")
+      if (value.value !== undefined && value.comparator) {
+        const unit = value.unit || value.code || '';
+        return <span>
+          <strong>{value.comparator} {value.value}</strong>{unit ? ` ${unit}` : ''}
+        </span>;
+      }
+      
+      // Handle quantity without unit but with code (e.g., "120 mm[Hg]")
+      if (value.value !== undefined && value.code && !value.unit) {
+        return <span>
+          <strong>{value.value}</strong> {value.code}
+        </span>;
+      }
+      
+      // Handle nested values (generic .value extraction - must come AFTER quantity checks)
       if (value.value !== undefined) {
         return renderFhirValue(value.value, fieldKey);
       }
@@ -144,13 +166,6 @@ const DynamicResourceTab = ({
           color: '#0066cc'
         }}>
           {value.reference}
-        </span>;
-      }
-      
-      // Handle quantity objects with units
-      if (value.value !== undefined && value.unit) {
-        return <span>
-          <strong>{value.value}</strong> {value.unit}
         </span>;
       }
       


### PR DESCRIPTION
Fixes #14
## Summary
Fixes a logic ordering bug in `renderFhirValue()` where FHIR Quantity types were rendered without their units due to unreachable code.


## Solution

### Fix: Reorder Checks (Specific Before Generic)
Changed `renderFhirValue()` to check for Quantity types before the generic `.value` extraction:

```javascript
// AFTER (fixed)
if (typeof value === 'object' && value !== null) {
  // Check quantity FIRST (more specific: has both value AND unit)
  if (value.value !== undefined && value.unit) {
    return <span><strong>{value.value}</strong> {value.unit}</span>;
  }

  // Handle quantity with comparator (e.g., "< 5 mg/dL")
  if (value.value !== undefined && value.comparator) {
    const unit = value.unit || value.code || '';
    return <span><strong>{value.comparator} {value.value}</strong>{unit ? ` ${unit}` : ''}</span>;
  }

  // Handle quantity without unit but with code (e.g., "120 mm[Hg]")
  if (value.value !== undefined && value.code && !value.unit) {
    return <span><strong>{value.value}</strong> {value.code}</span>;
  }

  // Then fall back to generic .value extraction
  if (value.value !== undefined) {
    return renderFhirValue(value.value, fieldKey);
  }
}
```

### Why This Works
The more specific condition (value + unit) is now checked before the general condition (value only). This follows the principle of checking specific cases before generic fallbacks.

## Testing

### Manual Validation
1. Navigate to a patient's Observations that include Quantity values (e.g., vital signs, lab results)
2. Verify values display with their units (e.g., "120 mmHg", "37.2 °C", "5.5 mmol/L")
3. Verify non-Quantity values with `.value` still render correctly (CodeableConcept, etc.)
4. Check that no existing rendering is broken by the reordering

### Test Cases
| Scenario | Input | Expected Output |
|----------|-------|-----------------|
| Quantity with unit | `{value: 120, unit: "mmHg"}` | `120 mmHg` |
| Quantity with comparator | `{value: 5, comparator: "<", unit: "mg/dL"}` | `< 5 mg/dL` |
| Quantity with code only | `{value: 120, code: "mm[Hg]"}` | `120 mm[Hg]` |
| Plain value object | `{value: "active"}` | `active` (recursive) |
| CodeableConcept | `{coding: [...], text: "Hypertension"}` | `Hypertension` |


## Clinical Significance
In a clinical data viewer, displaying "120" instead of "120 mmHg" for a blood pressure reading is a clinical context loss. Units differentiate between:
- `mg` vs `g` (1000x difference)
- `mmHg` vs `kPa` (different measurement systems)
- `days` vs `hours` (24x difference)