### PR TITLE
fix: use stagedFilters for state filter checkbox rendering

### DIFF
--- a/src/DynamicFilterSidebar.js
+++ b/src/DynamicFilterSidebar.js
@@ -528,7 +528,7 @@ const DynamicFilterSidebar = ({
                     <input 
                       type="checkbox" 
                       className="filter-checkbox"
-                      checked={(activeFilters.state || []).includes(option.value)}
+                      checked={(stagedFilters.state || []).includes(option.value)}
                       onChange={(e) => handleFilterChange('state', option.value, e.target.checked)}
                     />
                     <span className="filter-option-text">


### PR DESCRIPTION
Fixes #15

## Summary
Fixes an inconsistency in `DynamicFilterSidebar.js` where state filter checkboxes used `activeFilters` instead of `stagedFilters` for their visual checked state, breaking the staged filter UX pattern.

## Solution

### Fix: Use `stagedFilters` for Checkbox State
Changed the `checked` prop in `renderStateFilter()` to read from `stagedFilters`:

```javascript
// AFTER (fixed)
checked={(stagedFilters.state || []).includes(option.value)}
```

### Why This Works
The staged filter pattern is a deliberate UX design:
- User clicks checkboxes → updates `stagedFilters` (visual feedback immediate)
- User clicks Apply → `stagedFilters` copied to `activeFilters` → API call triggered
- All filter types should read from `stagedFilters` for checkbox visual state

## Testing

### Manual Validation
1. Open the filter sidebar and expand the State/Province filter section
2. Check a state filter checkbox — it should visually check immediately (before clicking Apply)
3. Check another state checkbox — both should remain visually checked
4. Click "Clear" — all checkboxes should uncheck immediately
5. Click Apply — verify the correct filters are applied to the data
6. Compare behavior with another filter type (e.g., gender) — behavior should be identical

### Test Cases
| Scenario | Before Fix | After Fix |
|----------|------------|-----------|
| Check state checkbox | No visual change until Apply | Immediate visual check |
| Uncheck state checkbox | No visual change until Apply | Immediate visual uncheck |
| Check multiple states | Only shows after Apply | All show checked immediately |
| Clear button | May show stale state | Immediately clears all |
| Apply then modify | Shows applied state, not staged | Shows current staged state |