### PR TITLE
Fix CSV Export Escaping for Quotes and Newlines

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -688,9 +688,15 @@ const MainPage = () => {
       const values = headers.map((header) => {
         const value = row[header];
         if (value === null || value === undefined) return "";
-        return typeof value === "string" && value.includes(",")
-          ? `"${value}"`
-          : value;
+        // Convert to string for consistent handling
+        const strValue = String(value);
+        // Check if value needs quoting (contains comma, double quote, or newline)
+        const needsQuoting = strValue.includes(",") || strValue.includes('"') || strValue.includes("\n") || strValue.includes("\r");
+        if (needsQuoting) {
+          // Escape double quotes by doubling them, then wrap in quotes (RFC 4180)
+          return `"${strValue.replace(/"/g, '""')}"`;
+        }
+        return strValue;
       });
       csvRows.push(values.join(","));
     });


### PR DESCRIPTION
Fixes #16 
## Summary
Fixes the `convertToCSV()` function to properly escape double quotes and newlines according to RFC 4180, preventing CSV corruption when exporting clinical data.

## Problem
The CSV export function only handled commas but did **not** escape:
- **Double quotes** (`"`) — caused Excel/Sheets to misinterpret field boundaries
- **Newlines** (`\n`, `\r`) — treated as new rows instead of multi-line cell content

### Example of Broken Export
A clinical note like `Patient said "I feel fine"` would export as:
```csv
notes
Patient said "I feel fine"
```
This corrupts the CSV structure and shifts all subsequent rows.

## Solution
Updated the escaping logic in `src/App.js` (lines 687-700) to:
1. **Escape double quotes** by doubling them (`"` → `""`)
2. **Wrap values containing newlines** in quotes
3. **Convert all values to strings** for consistent handling

### Before vs After

| Input Value | Before (Broken) | After (Correct) |
|-------------|-----------------|-----------------|
| `hello` | `hello` | `hello` |
| `New York, NY` | `"New York, NY"` | `"New York, NY"` |
| `He said "hi"` | `He said "hi"` | `"He said ""hi"""`  |
| `Line1\nLine2` | Line1 + new row  | `"Line1\nLine2"` |
| `null` | `null` | `` (empty) |

## Testing
1. Open the app and navigate to a patient table
2. Click **Export CSV**
3. Open the CSV in Excel or Google Sheets
4. Verify:
   - Values with commas stay in correct columns
   - Values with quotes don't corrupt subsequent rows
   - Multi-line values appear in a single cell
5. Test with Python: `pandas.read_csv("export.csv")` should load without errors
