### PR TITLE
fix #21: consolidate path extraction into single module, add wildcard [*] support

### DIFF
--- a/fhir-backend-dynamic/app/routers/filters.py
+++ b/fhir-backend-dynamic/app/routers/filters.py
@@ -2,6 +2,7 @@
 from fastapi import APIRouter, HTTPException, Query
 from typing import Dict, List, Any, Optional
 from collections import defaultdict
+from app.services.path_extractor import extract_values_by_path
 import logging
 from datetime import datetime, timedelta
 from app.services import fhir
@@ -165,13 +166,13 @@ def build_filter_from_config(filter_config: Dict, resources: List[Dict]) -> Opti
         for resource in resources:
             # Apply category filter if specified (for Observation resources)
             if category_filter:
-                resource_categories = extract_value_by_path(resource, 'category[0].coding[0].code') or []
+                resource_categories = extract_values_by_path([resource], 'category[0].coding[0].code') or []
                 if not resource_categories or category_filter not in resource_categories:
                     continue
 
             # Extract raw values and display values
-            raw_vals = extract_value_by_path(resource, path) or []
-            disp_vals = extract_value_by_path(resource, display_path) or []
+            raw_vals = extract_values_by_path([resource], path) or []
+            disp_vals = extract_values_by_path([resource], display_path) or []
 
             # Process extracted values
             for i, rv in enumerate(raw_vals):
@@ -204,85 +205,6 @@ def build_filter_from_config(filter_config: Dict, resources: List[Dict]) -> Opti
         logger.error(f"Error building filter from config: {str(e)}")
         return None
 
-def extract_value_by_path(resource: Dict, path: str) -> List[str]:
-    """
-    Extract values from FHIR resource using path notation
-    Supports: field, field[0], field[*], nested.field.path
-    """
-    if not resource or not path:
-        return []
-
-    def get_nested_value(obj, path_parts):
-        if not obj or not path_parts:
-            return []
-        
-        part = path_parts[0]
-        remaining = path_parts[1:]
-        
-        # Handle array notation
-        if '[' in part and ']' in part:
-            field_name = part.split('[')[0]
-            index_part = part.split('[')[1].rstrip(']')
-            
-            if field_name not in obj:
-                return []
-            
-            field_value = obj[field_name]
-            
-            if not isinstance(field_value, list):
-                field_value = [field_value]
-            
-            results = []
-            
-            if index_part == '*' or index_part == '':
-                # Wildcard - process all items
-                for item in field_value:
-                    if remaining:
-                        results.extend(get_nested_value(item, remaining))
-                    else:
-                        results.append(item)
-            else:
-                # Specific index
-                try:
-                    idx = int(index_part)
-                    if 0 <= idx < len(field_value):
-                        if remaining:
-                            results.extend(get_nested_value(field_value[idx], remaining))
-                        else:
-                            results.append(field_value[idx])
-                except ValueError:
-                    pass
-            
-            return results
-        
-        else:
-            # Simple field access
-            if part not in obj:
-                return []
-            
-            value = obj[part]
-            
-            if remaining:
-                return get_nested_value(value, remaining)
-            else:
-                return [value] if not isinstance(value, list) else value
-
-    path_parts = path.split('.')
-    raw_results = get_nested_value(resource, path_parts)
-    
-    # Clean and convert results to strings
-    clean_results = []
-    for result in raw_results:
-        if result is not None:
-            if isinstance(result, dict):
-                # For complex objects, try to get display value
-                display_val = result.get('display') or result.get('text') or result.get('code')
-                if display_val:
-                    clean_results.append(str(display_val))
-            elif isinstance(result, (str, int, float, bool)):
-                clean_results.append(str(result))
-    
-    return clean_results
 
 def create_filter_options(values: List[str], display_values: List[str] = None) -> List[Dict]:
     """

--- a/fhir-backend-dynamic/app/services/path_extractor.py
+++ b/fhir-backend-dynamic/app/services/path_extractor.py
@@ -13,26 +13,11 @@ logger = logging.getLogger(__name__)
 
 def extract_values_by_path(resources: List[Dict[str, Any]], path: str) -> List[str]:
     """
-    Extract values from FHIR resources using JSON path notation
+    Extract values from a LIST of FHIR resources using JSON path notation.
+    Loops through every resource and collects all found values into one list.
     
-    Args:
-        resources: List of FHIR resource dictionaries
-        path: Dot+bracket notation path (e.g., "code.coding[0].code", "author[0].display")
-    
-    Returns:
-        List of string values found at the specified path across all resources
-        
-    Features:
-        - Tolerates missing fields/indices gracefully
-        - Skips invalid nodes without crashing
-        - Returns empty list if no values found
-        - Converts all values to strings for consistency
-        - No resource-specific branching or field name checking
-    
-    Examples:
-        extract_values_by_path(observations, "code.coding[0].code")
-        extract_values_by_path(documents, "author[0].display") 
-        extract_values_by_path(conditions, "clinicalStatus.coding[0].display")
+    Example: give it 10 Patient resources and path "gender", 
+             get back ["male", "female", "male", ...]
     """
     if not resources or not path:
         return []
@@ -45,13 +30,19 @@ def extract_values_by_path(resources: List[Dict[str, Any]], path: str) -> List[s
             
         try:
             value = extract_single_value_by_path(resource, path)
-            if value is not None:
-                # Convert to string and add to results
+            if value is None:
+                continue
+            # Value could be a list (from wildcard) or a single item
+            if isinstance(value, list):
+                for v in value:
+                    str_value = str(v).strip()
+                    if str_value:
+                        values.append(str_value)
+            else:
                 str_value = str(value).strip()
-                if str_value:  # Only add non-empty strings
+                if str_value:
                     values.append(str_value)
         except Exception as e:
-            # Log debug info but continue processing other resources
             logger.debug(f"Error extracting path '{path}' from resource: {str(e)}")
             continue
     
@@ -60,102 +51,123 @@ def extract_values_by_path(resources: List[Dict[str, Any]], path: str) -> List[s
 
 def extract_single_value_by_path(resource: Dict[str, Any], path: str) -> Optional[Any]:
     """
-    Extract a single value from one FHIR resource using path notation
+    Extract a value from ONE FHIR resource using path notation.
     
-    Args:
-        resource: Single FHIR resource dictionary
-        path: JSON path like "code.coding[0].code" or "valueQuantity.unit"
+    Supports:
+        - Simple fields:   "status"           → "active"
+        - Nested objects:  "code.text"        → "Blood Pressure"
+        - Numeric index:   "coding[0].code"   → "12345"
+        - Wildcard index:  "coding[*].code"   → ["12345", "67890"]
     
-    Returns:
-        The value at the path, or None if not found
-        
-    Path Syntax Support:
-        - Simple fields: "status", "gender"
-        - Nested objects: "code.text", "name.family"  
-        - Array access: "coding[0]", "name[0].given[0]"
-        - Complex paths: "author[0].practitionerRole.specialty[0].coding[0].display"
-        - Mixed syntax: "category[0].coding[0].code"
+    Returns None if path doesn't exist.
+    Returns a list if wildcard [*] is used.
     """
     if not resource or not path:
         return None
     
     try:
-        # Parse path into segments
         segments = parse_path_segments(path)
-        
-        # Walk through the resource following the path
-        current = resource
-        
-        for segment in segments:
-            if current is None:
-                return None
-                
-            if segment['type'] == 'field':
-                # Simple field access
-                if isinstance(current, dict):
-                    current = current.get(segment['name'])
-                else:
-                    return None
-                    
-            elif segment['type'] == 'array':
-                # Array field with index access
-                if isinstance(current, dict):
-                    current = current.get(segment['name'])
-                    if isinstance(current, list) and len(current) > segment['index']:
-                        current = current[segment['index']]
-                    else:
-                        return None
-                else:
-                    return None
-        
-        return current
-        
+        return _walk_segments(resource, segments)
     except Exception as e:
         logger.debug(f"Error parsing path '{path}': {str(e)}")
         return None
 
 
+def _walk_segments(current: Any, segments: list) -> Optional[Any]:
+    """
+    Recursively walk through path segments to extract a value.
+    This is the engine that powers extract_single_value_by_path.
+    
+    Think of it like following directions:
+    "Go to code → then go to coding → take the first item → get its display"
+    """
+    if not segments or current is None:
+        return current
+    
+    segment = segments[0]
+    remaining = segments[1:]
+    
+    if segment['type'] == 'field':
+        # Simple field: just look up the key in the dictionary
+        if not isinstance(current, dict):
+            return None
+        return _walk_segments(current.get(segment['name']), remaining)
+    
+    elif segment['type'] == 'array':
+        # Array with numeric index like coding[0]
+        if not isinstance(current, dict):
+            return None
+        field_value = current.get(segment['name'])
+        if not isinstance(field_value, list):
+            return None
+        index = segment['index']
+        if index >= len(field_value):
+            return None
+        return _walk_segments(field_value[index], remaining)
+    
+    elif segment['type'] == 'wildcard':
+        # Wildcard [*]: collect results from ALL items in the array
+        # Example: coding[*].display → ["Blood Pressure", "BP", ...]
+        if not isinstance(current, dict):
+            return None
+        field_value = current.get(segment['name'])
+        if not isinstance(field_value, list) or not field_value:
+            return None
+        
+        results = []
+        for item in field_value:
+            result = _walk_segments(item, remaining)
+            if result is None:
+                continue
+            # Result itself might be a list (nested wildcards)
+            if isinstance(result, list):
+                results.extend(result)
+            else:
+                results.append(result)
+        
+        return results if results else None
+    
+    return None
+
+
 def parse_path_segments(path: str) -> List[Dict[str, Union[str, int]]]:
     """
-    Parse a JSON path string into structured segments
+    Break a path string into structured pieces we can follow one by one.
     
-    Args:
-        path: Path string like "code.coding[0].display"
-    
-    Returns:
-        List of segment dictionaries with type, name, and optional index
-        
     Examples:
-        "code.text" → [{"type": "field", "name": "code"}, {"type": "field", "name": "text"}]
-        "coding[0].code" → [{"type": "array", "name": "coding", "index": 0}, {"type": "field", "name": "code"}]
+        "status"              → [{"type": "field", "name": "status"}]
+        "coding[0].code"      → [{"type": "array",    "name": "coding", "index": 0},
+                                  {"type": "field",    "name": "code"}]
+        "coding[*].code"      → [{"type": "wildcard", "name": "coding"},
+                                  {"type": "field",    "name": "code"}]
     """
     if not path:
         return []
     
     segments = []
-    
-    # Split by dots, but handle array brackets carefully
     parts = path.split('.')
     
     for part in parts:
         if not part:
             continue
-            
-        # Check if this part has array notation
+        
+        # Check for wildcard: coding[*]
+        wildcard_match = re.match(r'^([a-zA-Z_]\w*)\[\*\]$', part)
+        # Check for numeric index: coding[0]
         array_match = re.match(r'^([a-zA-Z_]\w*)\[(\d+)\]$', part)
         
-        if array_match:
-            # Array access like "coding[0]"
-            field_name = array_match.group(1)
-            index = int(array_match.group(2))
+        if wildcard_match:
+            segments.append({
+                'type': 'wildcard',
+                'name': wildcard_match.group(1)
+            })
+        elif array_match:
             segments.append({
                 'type': 'array',
-                'name': field_name,
-                'index': index
+                'name': array_match.group(1),
+                'index': int(array_match.group(2))
             })
         else:
-            # Simple field access
-            # Remove any invalid characters for safety
             clean_name = re.sub(r'[^a-zA-Z0-9_]', '', part)
             if clean_name:
                 segments.append({
@@ -168,34 +180,23 @@ def parse_path_segments(path: str) -> List[Dict[str, Union[str, int]]]:
 
 def extract_multiple_paths(resources: List[Dict[str, Any]], paths: Dict[str, str]) -> Dict[str, List[str]]:
     """
-    Extract values for multiple paths from resources efficiently
+    Convenience function: extract several paths at once from the same resources.
     
-    Args:
-        resources: List of FHIR resource dictionaries
-        paths: Dictionary mapping result keys to path strings
-               e.g., {"code": "code.coding[0].code", "display": "code.coding[0].display"}
+    Instead of calling extract_values_by_path 5 times, call this once with
+    a dictionary of {label: path} pairs.
     
-    Returns:
-        Dictionary mapping result keys to lists of extracted values
-        
     Example:
-        paths = {
-            "code": "code.coding[0].code",
-            "display": "code.coding[0].display", 
-            "status": "status"
-        }
+        paths = {"code": "code.coding[0].code", "display": "code.coding[0].display"}
         result = extract_multiple_paths(resources, paths)
-        # result = {"code": ["123", "456"], "display": ["Test A", "Test B"], "status": ["final", "final"]}
+        # → {"code": ["123", "456"], "display": ["Test A", "Test B"]}
     """
     if not resources or not paths:
         return {}
     
     results = {}
-    
     for key, path in paths.items():
         try:
-            values = extract_values_by_path(resources, path)
-            results[key] = values
+            results[key] = extract_values_by_path(resources, path)
         except Exception as e:
             logger.warning(f"Error extracting path '{path}' for key '{key}': {str(e)}")
             results[key] = []
@@ -205,113 +206,23 @@ def extract_multiple_paths(resources: List[Dict[str, Any]], paths: Dict[str, str
 
 def validate_path_syntax(path: str) -> bool:
     """
-    Validate if a path string has correct syntax
-    
-    Args:
-        path: Path string to validate
-    
-    Returns:
-        True if syntax is valid, False otherwise
-        
-    Valid Examples:
-        - "status"
-        - "code.text"  
-        - "coding[0].code"
-        - "author[0].display"
-        - "category[0].coding[0].display"
-    
-    Invalid Examples:
-        - "coding[]" (missing index)
-        - "coding[abc]" (non-numeric index)
-        - ".field" (leading dot)
-        - "field." (trailing dot)
-        - "field..subfield" (double dot)
+    Check if a path string is written correctly before trying to use it.
+    Returns True if valid, False if something looks wrong.
     """
     if not path or not isinstance(path, str):
         return False
-    
-    # Basic checks
     if path.startswith('.') or path.endswith('.') or '..' in path:
         return False
-    
     try:
         segments = parse_path_segments(path)
-        
-        # Must have at least one segment
         if not segments:
             return False
-        
-        # All segments must have valid names
         for segment in segments:
             if not segment.get('name') or not re.match(r'^[a-zA-Z_]\w*$', segment['name']):
                 return False
-            
-            # Array segments must have valid indices
             if segment['type'] == 'array':
                 if 'index' not in segment or not isinstance(segment['index'], int) or segment['index'] < 0:
                     return False
-        
         return True
-        
     except Exception:
         return False
-
-
-def get_available_paths(resources: List[Dict[str, Any]], max_depth: int = 3) -> List[str]:
-    """
-    Discover available paths in FHIR resources (for debugging/development)
-    
-    Args:
-        resources: List of FHIR resource dictionaries
-        max_depth: Maximum depth to traverse
-    
-    Returns:
-        List of discovered paths
-        
-    Note: This is a utility function for development/debugging.
-    Production code should use predefined paths from config.
-    """
-    if not resources:
-        return []
-    
-    paths = set()
-    
-    for resource in resources[:5]:  # Sample first 5 resources
-        if isinstance(resource, dict):
-            discovered = _discover_paths_recursive(resource, "", max_depth)
-            paths.update(discovered)
-    
-    return sorted(list(paths))
-
-
-def _discover_paths_recursive(obj: Any, current_path: str, max_depth: int) -> List[str]:
-    """
-    Recursively discover paths in a nested object
-    """
-    if max_depth <= 0:
-        return []
-    
-    paths = []
-    
-    if isinstance(obj, dict):
-        for key, value in obj.items():
-            # Skip certain FHIR system fields
-            if key in ['resourceType', 'id', 'meta', 'text']:
-                continue
-                
-            new_path = f"{current_path}.{key}" if current_path else key
-            
-            if isinstance(value, (str, int, float, bool)):
-                paths.append(new_path)
-            elif isinstance(value, list) and value:
-                # Handle arrays
-                if isinstance(value[0], (str, int, float, bool)):
-                    paths.append(f"{new_path}[0]")
-                elif isinstance(value[0], dict):
-                    sub_paths = _discover_paths_recursive(value[0], f"{new_path}[0]", max_depth - 1)
-                    paths.extend(sub_paths)
-            elif isinstance(value, dict):
-                sub_paths = _discover_paths_recursive(value, new_path, max_depth - 1)
-                paths.extend(sub_paths)
-    
-    return paths

--- a/fhir-backend-dynamic/app/services/schema.py
+++ b/fhir-backend-dynamic/app/services/schema.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List
 from collections import defaultdict
+from app.services.path_extractor import extract_single_value_by_path
 import logging
 
 logger = logging.getLogger(__name__)
@@ -104,7 +105,7 @@ def analyze_sample_values(resources: List[Dict], path: str) -> Dict[str, Any]:
     
     try:
         for resource in resources:
-            value = _extract_value_by_path(resource, path)
+            value = extract_single_value_by_path(resource, path)
             if value is not None:
                 values.append(value)
                 value_types.add(type(value).__name__)
@@ -119,70 +120,3 @@ def analyze_sample_values(resources: List[Dict], path: str) -> Dict[str, Any]:
     except Exception as e:
         logger.error(f"Error analyzing values for path {path}: {str(e)}")
         return {"sample_count": 0, "all_null": True}
-
-def _extract_value_by_path(resource: Dict, path: str) -> Any:
-    """
-    Extract value from resource using dotted path notation
-    Handles arrays with [index] notation
-    """
-    try:
-        current = resource
-        parts = _parse_path(path)
-        
-        for part in parts:
-            if isinstance(part, dict) and part.get("type") == "array_index":
-                if isinstance(current, list) and part["index"] < len(current):
-                    current = current[part["index"]]
-                else:
-                    return None
-            elif isinstance(current, dict) and part in current:
-                current = current[part]
-            else:
-                return None
-                
-        return current
-    except Exception:
-        return None
-
-def _parse_path(path: str) -> List:
-    """
-    Parse dotted path with array indices into parts
-    Example: "code.coding[0].display" -> ["code", "coding", {"type": "array_index", "index": 0}, "display"]
-    """
-    parts = []
-    current = ""
-    i = 0
-    
-    while i < len(path):
-        char = path[i]
-        
-        if char == '.':
-            if current:
-                parts.append(current)
-                current = ""
-        elif char == '[':
-            # Found array index
-            if current:
-                parts.append(current)
-                current = ""
-            # Find closing bracket
-            j = i + 1
-            while j < len(path) and path[j] != ']':
-                j += 1
-            if j < len(path):
-                try:
-                    index = int(path[i+1:j])
-                    parts.append({"type": "array_index", "index": index})
-                except ValueError:
-                    pass  # Invalid index, skip
-                i = j
-            else:
-                break  # No closing bracket
-        else:
-            current += char
-        i += 1
-    
-    if current:
-        parts.append(current)
-        
-    return parts

--- a/fhir-backend-dynamic/tests/test_path_extractor.py
+++ b/fhir-backend-dynamic/tests/test_path_extractor.py
@@ -1,0 +1,69 @@
+"""
+Tests for the consolidated path extractor.
+Run with: pytest tests/test_path_extractor.py -v
+"""
+import pytest
+from app.services.path_extractor import extract_single_value_by_path, extract_values_by_path
+
+
+# ── Simple field ──────────────────────────────────────────────
+def test_simple_field():
+    """Grabbing a top-level field like 'status' should just work."""
+    resource = {"status": "active"}
+    assert extract_single_value_by_path(resource, "status") == "active"
+
+
+# ── Nested path ───────────────────────────────────────────────
+def test_nested_path():
+    """Grabbing a value buried inside nested objects."""
+    resource = {"code": {"coding": [{"display": "Blood Pressure"}]}}
+    result = extract_single_value_by_path(resource, "code.coding[0].display")
+    assert result == "Blood Pressure"
+
+
+# ── Wildcard ──────────────────────────────────────────────────
+def test_wildcard_returns_all_items():
+    """[*] should collect values from every item in the array."""
+    resource = {
+        "code": {
+            "coding": [
+                {"display": "BP"},
+                {"display": "Blood Pressure"}
+            ]
+        }
+    }
+    result = extract_single_value_by_path(resource, "code.coding[*].display")
+    assert result == ["BP", "Blood Pressure"]
+
+
+# ── Missing path ──────────────────────────────────────────────
+def test_missing_path_returns_none():
+    """If the path doesn't exist, return None — don't crash."""
+    resource = {"status": "active"}
+    assert extract_single_value_by_path(resource, "nonexistent.field") is None
+
+
+# ── Empty array ───────────────────────────────────────────────
+def test_empty_array_returns_none():
+    """If the array is empty, there's nothing to return."""
+    resource = {"code": {"coding": []}}
+    assert extract_single_value_by_path(resource, "code.coding[0].display") is None
+
+
+# ── Wildcard on empty array ───────────────────────────────────
+def test_wildcard_empty_array_returns_none():
+    """Wildcard on empty array should also return None."""
+    resource = {"code": {"coding": []}}
+    assert extract_single_value_by_path(resource, "code.coding[*].display") is None
+
+
+# ── extract_values_by_path (list version) ────────────────────
+def test_extract_values_across_multiple_resources():
+    """The list version should collect values from all resources."""
+    resources = [
+        {"status": "active"},
+        {"status": "inactive"},
+        {"status": "active"},
+    ]
+    result = extract_values_by_path(resources, "status")
+    assert result == ["active", "inactive", "active"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -3132,69 +3132,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jsonjoy.com/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/json-pack": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.2.0.tgz",
-      "integrity": "sha512-io1zEbbYcElht3tdlqEOFxZ0dMTYrHz9iMf0gqn1pPjZFTCgM5R4R5IMA20Chb2UPYYsxjzs8CgZ7Nb5n2K2rA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jsonjoy.com/base64": "^1.1.1",
-        "@jsonjoy.com/util": "^1.1.2",
-        "hyperdyperid": "^1.2.0",
-        "thingies": "^1.20.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@jsonjoy.com/util": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.6.0.tgz",
-      "integrity": "sha512-sw/RMbehRhN68WRtcKCpQOPfnH6lLP4GJfqzi3iYej8tnzpZUDr6UkZYJjcjjC0FWEJOJbyM3PTIwxucUmDG2A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -4015,15 +3952,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
-      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/semver": {
       "version": "7.7.0",
@@ -5659,24 +5587,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bundle-name": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -6872,40 +6782,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/default-browser": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bundle-name": "^4.1.0",
-        "default-browser-id": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser-id": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/default-gateway": {
@@ -9755,18 +9631,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/hyperdyperid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
-      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.18"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -10191,45 +10055,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container/node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -10261,21 +10086,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-network-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
-      "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -12834,26 +12644,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/p-retry": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
-      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/retry": "0.12.2",
-        "is-network-error": "^1.0.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -15738,21 +15528,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/run-applescript": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -17476,21 +17251,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/thingies": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
-      "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
-      "dev": true,
-      "license": "Unlicense",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.18"
-      },
-      "peerDependencies": {
-        "tslib": "^2"
-      }
-    },
     "node_modules/throat": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz",
@@ -17572,25 +17332,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/tree-dump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.3.tgz",
-      "integrity": "sha512-il+Cv80yVHFBwokQSfd4bldvr1Md951DpgAGfmhydt04L+YzHgubm2tQ7zueWDcGENKHq0ZvGFR/hjvNXilHEg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
       }
     },
     "node_modules/tryer": {
@@ -18200,198 +17941,6 @@
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-dev-middleware": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.2.tgz",
-      "integrity": "sha512-xOO8n6eggxnwYpy1NlzUKpvrjfJTvae5/D6WOK0S2LSo7vjmo5gCM1DbLUmFqrMTJP+W/0YZNctm7jasWvLuBA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "colorette": "^2.0.10",
-        "memfs": "^4.6.0",
-        "mime-types": "^2.1.31",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "schema-utils": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/memfs": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.17.2.tgz",
-      "integrity": "sha512-NgYhCOWgovOXSzvYgUW0LQ7Qy72rWQMGGFJDoWg4G30RHd3z77VbYdtJ4fembJXBy8pMIUA31XNAupobOQlwdg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jsonjoy.com/json-pack": "^1.0.3",
-        "@jsonjoy.com/util": "^1.3.0",
-        "tree-dump": "^1.0.1",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      }
-    },
-    "node_modules/webpack-dev-server": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
-      "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/bonjour": "^3.5.13",
-        "@types/connect-history-api-fallback": "^1.5.4",
-        "@types/express": "^4.17.21",
-        "@types/express-serve-static-core": "^4.17.21",
-        "@types/serve-index": "^1.9.4",
-        "@types/serve-static": "^1.15.5",
-        "@types/sockjs": "^0.3.36",
-        "@types/ws": "^8.5.10",
-        "ansi-html-community": "^0.0.8",
-        "bonjour-service": "^1.2.1",
-        "chokidar": "^3.6.0",
-        "colorette": "^2.0.10",
-        "compression": "^1.7.4",
-        "connect-history-api-fallback": "^2.0.0",
-        "express": "^4.21.2",
-        "graceful-fs": "^4.2.6",
-        "http-proxy-middleware": "^2.0.9",
-        "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
-        "open": "^10.0.3",
-        "p-retry": "^6.2.0",
-        "schema-utils": "^4.2.0",
-        "selfsigned": "^2.4.1",
-        "serve-index": "^1.9.1",
-        "sockjs": "^0.3.24",
-        "spdy": "^4.0.2",
-        "webpack-dev-middleware": "^7.4.2",
-        "ws": "^8.18.0"
-      },
-      "bin": {
-        "webpack-dev-server": "bin/webpack-dev-server.js"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack": {
-          "optional": true
-        },
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/open": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
-      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }


### PR DESCRIPTION
Consolidates three duplicate path extraction functions into a single shared module as described in issue #21.

Changes Made:
- Enhanced `path_extractor.py` with wildcard [*] support
- Removed `_extract_value_by_path()` and `_parse_path()` from `schema.py`
- Removed `extract_value_by_path()` from `filters.py`
- All callers now import from `app.services.path_extractor`
- Added tests in `tests/test_path_extractor.py` (7 tests, all passing)

All 7 tests passing
Server starts cleanly
Closes #21

