### PR TITLE
feat: Add unified single-command developer workflow using npm run dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,8 +311,8 @@ extractMedicalData(resources);
 ### Prerequisites
 
 - Node.js (v14 or higher)
+- Python 3.8 to 3.12 (Python 3.13+ not currently supported due to pydantic compatibility)
 - NPM or Yarn package manager
-- Backend FastAPI server (running on port 8000)
 - Access to FHIR-compliant server
 
 ### Installation Steps
@@ -324,14 +324,32 @@ git clone <repository-url>
 cd final-fhir
 ```
 
-2. **Install Dependencies**
+2. **Install Frontend Dependencies**
 
 ```bash
 npm install
 ```
 
-3. **Configure Environment**
-   Create `.env` file:
+3. **Set Up Backend Virtual Environment**
+
+**Important:** You must create and set up the virtual environment before running `npm run dev`.
+
+```bash
+cd fhir-backend-dynamic
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+cd ..
+```
+
+**Note:** If you get an error about `python3-venv` not being available, install it first:
+```bash
+# On Ubuntu/Debian:
+sudo apt install python3-venv
+```
+
+4. **Configure Environment**
+   Create `.env` file in `fhir-backend-dynamic/` directory:
 
 ```env
 REACT_APP_API_BASE_URL=http://localhost:8000
@@ -339,14 +357,25 @@ REACT_APP_FHIR_BASE_URL=https://hapi.fhir.org/baseR4/
 REACT_APP_TITLE=FHIR Patient Search
 ```
 
-4. **Start Development Server**
+5. **Start Development Servers**
 
 ```bash
-npm start
+npm run dev
 ```
 
-5. **Access Application**
-   Navigate to `http://localhost:3000`
+This single command starts both:
+- Frontend (React) on `http://localhost:3000`
+- Backend (FastAPI) on `http://localhost:8000`
+
+**Note for Windows users:** The startup script uses POSIX shell syntax. Windows users should either use WSL (Windows Subsystem for Linux) or start the backend manually:
+
+```bash
+cd fhir-backend-dynamic
+.venv\Scripts\activate
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Then in a separate terminal, run `npm start` for the frontend.
 
 ### Production Build
 

--- a/README.md
+++ b/README.md
@@ -306,36 +306,24 @@ extractMedicalData(resources);
 | `/api/filters/targets`                | GET    | Get filter configurations     |
 | `/api/filters/{type}/metadata`        | GET    | Get resource-specific filters |
 
-## Installation & Setup
+## Setup
 
-### Prerequisites
+### Requirements
 
-- Node.js (v14 or higher)
-- Python 3.8 to 3.12 (Python 3.13+ not currently supported due to pydantic compatibility)
-- NPM or Yarn package manager
-- Access to FHIR-compliant server
+- Node.js v14+
+- Python 3.8+
+- npm
 
-### Installation Steps
+### Installation
 
-1. **Clone Repository**
-
+1. Clone and install dependencies:
 ```bash
-git clone <repository-url>
+git clone <repo-url>
 cd final-fhir
-```
-
-2. **Install Frontend Dependencies**
-
-```bash
 npm install
 ```
 
-3. **Set Up Backend Virtual Environment**
-
-**Important:** You must create and set up the virtual environment before running `npm run dev`.
-
-**Note:** The virtual environment (`.venv`) is not committed to the repository. All contributors must create it locally.
-
+2. Setup backend:
 ```bash
 cd fhir-backend-dynamic
 python3 -m venv .venv
@@ -344,69 +332,39 @@ pip install -r requirements.txt
 cd ..
 ```
 
-**Note:** If you get an error about `python3-venv` not being available, install it first:
-```bash
-# On Ubuntu/Debian:
-sudo apt install python3-venv
+3. Create `.env`:
 ```
-
-4. **Configure Environment**
-   Create `.env` file in the project root:
-
-```env
 REACT_APP_API_BASE_URL=http://localhost:8000
 REACT_APP_FHIR_BASE_URL=https://hapi.fhir.org/baseR4/
 REACT_APP_TITLE=FHIR Patient Search
 ```
 
-5. **Start Development Servers**
-
+4. Start development:
 ```bash
 npm run dev
 ```
 
-This command starts both:
-- Frontend (React) on `http://localhost:3000`
-- Backend (FastAPI) on `http://localhost:8000`
+Opens frontend at http://localhost:3000 and backend at http://localhost:8000.
 
-**Technical Notes:**
-- Uses `start-backend-dev.sh` - a basic POSIX shell script
-- Script activates virtual environment and runs uvicorn
-- Virtual environment (`.venv`) is not committed - contributors must create locally
+### Windows Users
 
-**Platform Notes:**
-- ✅ **Linux/macOS**: `npm run dev` works directly
-- ⚠️ **Windows**: **Must use WSL (Windows Subsystem for Linux)** or run backend manually:
-  
-  **Option 1 - WSL (Recommended):**
-  ```bash
-  # In WSL terminal
-  npm run dev
-  ```
-  
-  **Option 2 - Manual (PowerShell/CMD):**
-  
-  **PowerShell:**
-  ```powershell
-  # Terminal 1 - Backend
-  cd fhir-backend-dynamic
-  .\.venv\Scripts\Activate.ps1
-  python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
-  
-  # Terminal 2 - Frontend  
-  npm start
-  ```
-  
-  **Command Prompt (CMD):**
-  ```cmd
-  # Terminal 1 - Backend
-  cd fhir-backend-dynamic
-  .venv\Scripts\activate.bat
-  python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
-  
-  # Terminal 2 - Frontend  
-  npm start
-  ```
+Use WSL or run manually:
+
+PowerShell:
+```powershell
+cd fhir-backend-dynamic
+.\.venv\Scripts\Activate.ps1
+python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+CMD:
+```cmd
+cd fhir-backend-dynamic
+.venv\Scripts\activate.bat
+python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Then run `npm start` in another terminal.
 
 
 

--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ npm install
 
 **Important:** You must create and set up the virtual environment before running `npm run dev`.
 
+**Note:** The virtual environment (`.venv`) is not committed to the repository. All contributors must create it locally.
+
 ```bash
 cd fhir-backend-dynamic
 python3 -m venv .venv
@@ -349,7 +351,7 @@ sudo apt install python3-venv
 ```
 
 4. **Configure Environment**
-   Create `.env` file in `fhir-backend-dynamic/` directory:
+   Create `.env` file in the project root:
 
 ```env
 REACT_APP_API_BASE_URL=http://localhost:8000
@@ -363,19 +365,50 @@ REACT_APP_TITLE=FHIR Patient Search
 npm run dev
 ```
 
-This single command starts both:
+This command starts both:
 - Frontend (React) on `http://localhost:3000`
 - Backend (FastAPI) on `http://localhost:8000`
 
-**Note for Windows users:** The startup script uses POSIX shell syntax. Windows users should either use WSL (Windows Subsystem for Linux) or start the backend manually:
+**Technical Notes:**
+- Uses `start-backend-dev.sh` - a basic POSIX shell script
+- Script activates virtual environment and runs uvicorn
+- Virtual environment (`.venv`) is not committed - contributors must create locally
 
-```bash
-cd fhir-backend-dynamic
-.venv\Scripts\activate
-uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
-```
+**Platform Notes:**
+- ✅ **Linux/macOS**: `npm run dev` works directly
+- ⚠️ **Windows**: **Must use WSL (Windows Subsystem for Linux)** or run backend manually:
+  
+  **Option 1 - WSL (Recommended):**
+  ```bash
+  # In WSL terminal
+  npm run dev
+  ```
+  
+  **Option 2 - Manual (PowerShell/CMD):**
+  
+  **PowerShell:**
+  ```powershell
+  # Terminal 1 - Backend
+  cd fhir-backend-dynamic
+  .\.venv\Scripts\Activate.ps1
+  python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+  
+  # Terminal 2 - Frontend  
+  npm start
+  ```
+  
+  **Command Prompt (CMD):**
+  ```cmd
+  # Terminal 1 - Backend
+  cd fhir-backend-dynamic
+  .venv\Scripts\activate.bat
+  python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+  
+  # Terminal 2 - Frontend  
+  npm start
+  ```
 
-Then in a separate terminal, run `npm start` for the frontend.
+
 
 ### Production Build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "react-router-dom": "7.8.2"
       },
       "devDependencies": {
-        "concurrently": "^9.2.1",
+        "concurrently": "^7.6.0",
         "react-scripts": "5.0.1"
       }
     },
@@ -6211,25 +6211,28 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.6.0.tgz",
+      "integrity": "sha512-BKtRgvcJGeZ4XttiDiNcFiRlxoAeZOseqUvyYRUp/Vtd+9p1ULmeoSqGsDA+2ivdeDFpqrJvGvmI+StKfKl5hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "4.1.2",
-        "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
-        "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
+        "chalk": "^4.1.0",
+        "date-fns": "^2.29.1",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.0.0",
+        "shell-quote": "^1.7.3",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^8.1.0",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.3.1"
       },
       "bin": {
         "conc": "dist/bin/concurrently.js",
         "concurrently": "dist/bin/concurrently.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^12.20.0 || ^14.13.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
@@ -6912,6 +6915,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -16577,6 +16597,12 @@
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+      "dev": true
     },
     "node_modules/spdy": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-router-dom": "7.8.2"
       },
       "devDependencies": {
+        "concurrently": "^9.2.1",
         "react-scripts": "5.0.1"
       }
     },
@@ -75,6 +76,7 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -760,6 +762,7 @@
       "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1682,6 +1685,7 @@
       "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
         "@babel/helper-module-imports": "^7.27.1",
@@ -3139,7 +3143,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10.0"
       },
@@ -3158,7 +3161,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jsonjoy.com/base64": "^1.1.1",
         "@jsonjoy.com/util": "^1.1.2",
@@ -3183,7 +3185,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10.0"
       },
@@ -4022,8 +4023,7 @@
       "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/semver": {
       "version": "7.7.0",
@@ -4122,6 +4122,7 @@
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -4177,6 +4178,7 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -4576,6 +4578,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4670,6 +4673,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5616,6 +5620,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -5666,7 +5671,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "run-applescript": "^7.0.0"
       },
@@ -6205,6 +6209,91 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
@@ -6881,7 +6970,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "bundle-name": "^4.1.0",
         "default-browser-id": "^5.0.0"
@@ -6900,7 +6988,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7638,6 +7725,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9762,7 +9850,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10.18"
       }
@@ -10198,7 +10285,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "is-docker": "^3.0.0"
       },
@@ -10219,7 +10305,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -10270,7 +10355,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -10723,6 +10807,7 @@
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -12843,7 +12928,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/retry": "0.12.2",
         "is-network-error": "^1.0.0",
@@ -13175,6 +13259,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14433,6 +14518,7 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -14823,6 +14909,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14964,6 +15051,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14992,6 +15080,7 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15686,6 +15775,7 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -15745,7 +15835,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -15775,6 +15864,16 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -15961,6 +16060,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17483,7 +17583,6 @@
       "dev": true,
       "license": "Unlicense",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10.18"
       },
@@ -17581,7 +17680,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10.0"
       },
@@ -17591,6 +17689,16 @@
       },
       "peerDependencies": {
         "tslib": "2"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/tryer": {
@@ -17648,7 +17756,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -17702,6 +17811,7 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18162,6 +18272,7 @@
       "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -18211,7 +18322,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "colorette": "^2.0.10",
         "memfs": "^4.6.0",
@@ -18243,7 +18353,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jsonjoy.com/json-pack": "^1.0.3",
         "@jsonjoy.com/util": "^1.3.0",
@@ -18265,7 +18374,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -18325,7 +18433,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18340,7 +18447,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "is-inside-container": "^1.0.0"
       },
@@ -18358,7 +18464,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
@@ -18379,7 +18484,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -18757,6 +18861,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "proxy": "http://localhost:8000",
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "dependencies": {
     "lucide-react": "0.542.0",
     "react": "^18.3.1",
@@ -14,7 +17,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "dev": "concurrently \"sh start-backend-dev.sh\" \"npm start\""
+    "dev": "concurrently \"./start-backend-dev.sh\" \"npm start\""
   },
   "browserslist": {
     "production": [
@@ -29,7 +32,7 @@
     ]
   },
   "devDependencies": {
-    "concurrently": "^9.2.1",
+    "concurrently": "^7.6.0",
     "react-scripts": "5.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build", 
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "dev": "concurrently \"./start-backend-dev.sh\" \"npm start\""

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "dev": "concurrently \"sh start-backend-dev.sh\" \"npm start\""
   },
   "browserslist": {
     "production": [
@@ -28,6 +29,7 @@
     ]
   },
   "devDependencies": {
+    "concurrently": "^9.2.1",
     "react-scripts": "5.0.1"
   }
 }

--- a/start-backend-dev.sh
+++ b/start-backend-dev.sh
@@ -1,10 +1,8 @@
-#!/usr/bin/env sh
-set -e
-cd fhir-backend-dynamic || exit 1
+#!/bin/sh
+cd fhir-backend-dynamic
 if [ ! -f .venv/bin/activate ]; then
-    echo "Error: Virtual environment not found at .venv/bin/activate"
-    echo "Please create it with: python3 -m venv .venv && . .venv/bin/activate && pip install -r requirements.txt"
+    echo "No virtual environment found"
     exit 1
 fi
-. .venv/bin/activate || exit 1
+. .venv/bin/activate
 python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000

--- a/start-backend-dev.sh
+++ b/start-backend-dev.sh
@@ -1,5 +1,10 @@
+#!/usr/bin/env sh
+set -e
 cd fhir-backend-dynamic || exit 1
-
-. .venv/bin/activate
-
-uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+if [ ! -f .venv/bin/activate ]; then
+    echo "Error: Virtual environment not found at .venv/bin/activate"
+    echo "Please create it with: python3 -m venv .venv && . .venv/bin/activate && pip install -r requirements.txt"
+    exit 1
+fi
+. .venv/bin/activate || exit 1
+python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000

--- a/start-backend-dev.sh
+++ b/start-backend-dev.sh
@@ -1,7 +1,5 @@
-#!/bin/sh
-# Move to backend directory
 cd fhir-backend-dynamic || exit 1
-# Activate virtual environment
+
 . .venv/bin/activate
-# Run FastAPI
+
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000

--- a/start-backend-dev.sh
+++ b/start-backend-dev.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Move to backend directory
+cd fhir-backend-dynamic || exit 1
+# Activate virtual environment
+. .venv/bin/activate
+# Run FastAPI
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000


### PR DESCRIPTION
Summary:
This PR introduces a simple and documented developer workflow that allows contributors to start both the React frontend and FastAPI backend using a single command
command : npm run dev

Changes:
Added start-backend-dev.sh (POSIX shell script) to start the FastAPI backend
Added concurrently to run frontend and backend in parallel
Added dev script in package.json
Updated README.md with setup instructions, venv steps, ports, and Windows caveats.

How to Test:
Create backend virtual environment:
python3 -m venv .venv
pip install -r fhir-backend-dynamic/requirements.txt
Run:
npm run dev
Verify:
Frontend → http://localhost:3000/
Backend →  http://localhost:8000/

Impact:
Reduces onboarding friction
Provides consistent local development workflow
No changes to existing application logic

Implemented #33 successfully completed 