### PR TITLE
Enhance logging middleware with precise timing and format

### DIFF
--- a/fhir-backend-dynamic/app/core/logging.py
+++ b/fhir-backend-dynamic/app/core/logging.py
@@ -1,21 +1,45 @@
-import logging, time, uuid
+import logging
+import time
+import uuid
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
+
+logger = logging.getLogger("app.request")
+
 class RequestContextMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
+        
         request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
-        start = time.time()
+        
+        start_time = time.perf_counter()
+        
         try:
             response = await call_next(request)
+        except Exception as e:
+           
+            logger.error("Request Failed | ID: %s | Error: %s", request_id, str(e))
+            raise e
         finally:
-            duration = (time.time() - start) * 1000
-            logging.getLogger("app").info(
-                f"{request.method} {request.url.path} -> {getattr(response, 'status_code', None)} in {duration:.1f}ms",
+            
+            process_time = (time.perf_counter() - start_time) * 1000
+            logger.info(
+                "%s %s | Status: %s | Latency: %.2fms | ID: %s",
+                request.method,
+                request.url.path,
+                getattr(response, 'status_code', '500'),
+                process_time,
+                request_id
             )
+        
+        
         response.headers["x-request-id"] = request_id
         return response
 
 def setup_logging(app):
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s :: %(message)s")
+    # Use a cleaner format for Cloud Log Explorers
+    logging.basicConfig(
+        level=logging.INFO, 
+        format="%(levelname)s: [%(name)s] %(message)s"
+    )
     app.add_middleware(RequestContextMiddleware)


### PR DESCRIPTION
This PR/feature is useful in app/core/logging.py because:

**1. Monotonic Precision (perf_counter)**: [from line 14]
The original code used time.time(), which measures "Wall Clock" time. If the server synchronizes its clock with an NTP server (a common event in Cloud environments) during a request, your duration could suddenly become a negative number or an impossibly large one, whereas time.perf_counter() is a monotonic clock. It is guaranteed to never move backward and has much higher resolution.

**2. Failure-Resilient Logging**: [from line 19]
In the original code, if call_next(request) raised an unhandled exception, the request might finish without the request_id being logged alongside the error.
 By adding an explicit except Exception block that logs the request_id before re-raising, you ensure that even a "Hard Crash" is traceable.

**3. Memory & CPU Efficiency (Lazy Interpolation)**: 
The original code used f-strings: f"... {duration}ms". In Python, f-strings are evaluated immediately when the line is reached, even if the logging level is set to WARNING and the INFO message isn't actually being printed.
Using logger.info("... %s", duration) uses Lazy Interpolation. The string is only formatted if the logger is actually going to write the message.

