### PR TITLE
 Stabilize aggregate datasets and add profile/schema metadata endpoints

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -100,7 +100,7 @@ backend:
 
   # Aggregate Dataset Configuration
   aggregate:
-    enabled: false                    # TEMPORARILY DISABLED - causing issues
+    enabled: true
     max_records: 200000              # Safety cap per dataset
     page_count_hint: 100             # Hint for FHIR server _count parameter
     max_build_time_seconds: 300      # Timeout for long aggregations

--- a/fhir-backend-dynamic/app/main.py
+++ b/fhir-backend-dynamic/app/main.py
@@ -1,8 +1,7 @@
 # app/main.py - Updated to include startup system and configuration
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import resources, health, servers, filters, metadata
-# , aggregate  # TEMPORARILY DISABLED
+from app.routers import resources, health, servers, filters, metadata, aggregate
 from app.core.logging import setup_logging
 from app.startup import initialize_backend, get_startup_status
 from app.config import config
@@ -87,15 +86,14 @@ app.include_router(filters.router,    prefix="/api")  # Filter endpoints
 app.include_router(metadata.router,   prefix="/api")  # NEW: FHIR Metadata endpoints
 
 # Conditionally include aggregate router behind feature flag
-# TEMPORARILY DISABLED - causing issues
-# if config.aggregate_enabled:
-#     try:
-#         app.include_router(aggregate.router, prefix="/api")  # NEW: Aggregate dataset endpoints
-#         logging.info("🔗 Aggregate endpoints enabled successfully")
-#     except Exception as e:
-#         logging.error(f"❌ Failed to include aggregate router: {e}")
-#         import traceback
-#         traceback.print_exc()
+if config.aggregate_enabled:
+    try:
+        app.include_router(aggregate.router, prefix="/api")
+        logging.info("🔗 Aggregate endpoints enabled successfully")
+    except Exception as e:
+        logging.error(f"❌ Failed to include aggregate router: {e}")
+        import traceback
+        traceback.print_exc()
 
 @app.get("/")
 async def home():

--- a/fhir-backend-dynamic/app/models/aggregate.py
+++ b/fhir-backend-dynamic/app/models/aggregate.py
@@ -19,6 +19,15 @@ class AggregateResponse(BaseModel):
     build_time_ms: int = Field(..., description="Time taken to build dataset in milliseconds")
     cache_hit: bool = Field(default=False, description="Whether response was served from cache")
 
+class ColumnDefinition(BaseModel):
+    """Lightweight column metadata for aggregate dataset schemas"""
+    name: str = Field(..., description="Display-friendly column name")
+    path: str = Field(..., description="Flattened path used to access the value")
+    inferred_type: str = Field(..., description="Logical type inferred from sample values")
+    nullable: bool = Field(..., description="Whether the column is missing in sampled resources")
+    repeated: bool = Field(..., description="Whether the column originates from repeated FHIR content")
+    example_values: List[str] = Field(default_factory=list, description="Example values from sampled resources")
+
 class SliceRequest(BaseModel):
     """Request model for getting dataset slice"""
     offset: int = Field(default=0, ge=0, description="Starting offset for pagination slice")
@@ -48,6 +57,30 @@ class ProgressResponse(BaseModel):
     completed_at: Optional[str] = Field(None, description="ISO timestamp when build completed")
     error_message: Optional[str] = Field(None, description="Error message if status is error")
     truncated: bool = Field(default=False, description="Whether dataset was truncated")
+
+class DatasetProfileResponse(BaseModel):
+    """Response model for aggregate dataset profile metadata"""
+    success: bool = Field(default=True)
+    dataset_id: str = Field(..., description="Dataset identifier")
+    source_id: str = Field(..., description="Source/server identifier used to build the dataset")
+    resource_type: str = Field(..., description="FHIR resource type in the dataset")
+    status: str = Field(..., description="Current status: building, ready, error, truncated")
+    progress_percent: int = Field(..., description="Completion percentage (0-100)")
+    total_records: int = Field(..., description="Total records in the dataset snapshot")
+    truncated: bool = Field(default=False, description="Whether the dataset hit configured caps")
+    build_time_ms: int = Field(..., description="Elapsed build time in milliseconds")
+    created_at: Optional[str] = Field(None, description="ISO timestamp when the dataset was created")
+    warnings: List[str] = Field(default_factory=list, description="Non-fatal dataset warnings")
+
+class DatasetSchemaResponse(BaseModel):
+    """Response model for inferred aggregate dataset schema"""
+    success: bool = Field(default=True)
+    dataset_id: str = Field(..., description="Dataset identifier")
+    resource_type: str = Field(..., description="FHIR resource type in the dataset")
+    flatten_profile: str = Field(default="default", description="Flattening profile used for schema inference")
+    columns: List[ColumnDefinition] = Field(default_factory=list, description="Inferred column definitions")
+    sampled_records: int = Field(default=0, description="Number of sampled records used for schema inference")
+    warnings: List[str] = Field(default_factory=list, description="Non-fatal schema inference warnings")
 
 class ErrorResponse(BaseModel):
     """Error response model"""

--- a/fhir-backend-dynamic/app/routers/aggregate.py
+++ b/fhir-backend-dynamic/app/routers/aggregate.py
@@ -11,7 +11,8 @@ from app.config import config
 from app.services.aggregation import get_aggregation_service
 from app.models.aggregate import (
     AggregateRequest, AggregateResponse, SliceRequest, SliceResponse,
-    ProgressResponse, ErrorResponse, DeleteResponse
+    ProgressResponse, ErrorResponse, DeleteResponse,
+    DatasetProfileResponse, DatasetSchemaResponse
 )
 
 router = APIRouter(prefix="/aggregate", tags=["aggregate"])
@@ -109,6 +110,58 @@ async def get_dataset_progress(
     except Exception as e:
         logger.error(f"Failed to get progress for dataset {dataset_id}: {e}")
         raise HTTPException(status_code=500, detail=f"Progress retrieval failed: {str(e)}")
+
+@router.get("/{dataset_id}/profile", response_model=DatasetProfileResponse)
+async def get_dataset_profile(
+    dataset_id: str,
+    user_session: str = Query(..., description="User session identifier"),
+    _: None = Depends(check_aggregate_enabled)
+):
+    """
+    Get dataset-level metadata for a cached aggregate dataset.
+    Returns status, counts, timing, and source identifiers for the dataset.
+    """
+    try:
+        aggregation_service = get_aggregation_service()
+        result = await aggregation_service.get_dataset_profile(
+            dataset_id=dataset_id,
+            user_id=user_session
+        )
+
+        return DatasetProfileResponse(**result)
+
+    except ValueError as e:
+        logger.warning(f"Dataset not found: {dataset_id}")
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        logger.error(f"Failed to get dataset profile {dataset_id}: {e}")
+        raise HTTPException(status_code=500, detail=f"Profile retrieval failed: {str(e)}")
+
+@router.get("/{dataset_id}/schema", response_model=DatasetSchemaResponse)
+async def get_dataset_schema(
+    dataset_id: str,
+    user_session: str = Query(..., description="User session identifier"),
+    _: None = Depends(check_aggregate_enabled)
+):
+    """
+    Get inferred schema metadata for a cached aggregate dataset.
+    Returns lightweight column definitions derived from sampled cached resources.
+    """
+    try:
+        aggregation_service = get_aggregation_service()
+        result = await aggregation_service.get_dataset_schema(
+            dataset_id=dataset_id,
+            user_id=user_session
+        )
+
+        return DatasetSchemaResponse(**result)
+
+    except ValueError as e:
+        logger.warning(f"Dataset not found: {dataset_id}")
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        logger.error(f"Failed to get dataset schema {dataset_id}: {e}")
+        raise HTTPException(status_code=500, detail=f"Schema retrieval failed: {str(e)}")
 
 @router.delete("/{dataset_id}", response_model=DeleteResponse)
 async def delete_dataset(

--- a/fhir-backend-dynamic/app/services/aggregation.py
+++ b/fhir-backend-dynamic/app/services/aggregation.py
@@ -4,7 +4,9 @@ Implements complete dataset fetching following FHIR Bundle.link pagination
 """
 
 import asyncio
+import json
 import logging
+import re
 import time
 from datetime import datetime
 from typing import Dict, List, Any, Optional, Tuple
@@ -13,6 +15,7 @@ from urllib.parse import urlencode
 from app.services import fhir
 from app.services.http import get_json
 from app.services.cache_manager import get_cache_manager
+from app.services.schema import infer_columns, analyze_sample_values
 from app.config import config
 
 logger = logging.getLogger(__name__)
@@ -76,6 +79,8 @@ class AggregationProgress:
 
 class AggregationService:
     """Service for building and managing aggregated FHIR resource datasets"""
+
+    SCHEMA_SAMPLE_SIZE = 25
     
     def __init__(self):
         self.cache_manager = get_cache_manager()
@@ -119,19 +124,24 @@ class AggregationService:
             resources, truncated = await self._fetch_all_resources(
                 resource_type, search_params, progress
             )
+
+            progress.complete(len(resources), truncated)
             
             # Store in cache
             dataset = {
                 "dataset_id": dataset_id,
+                "source_id": server_id,
                 "resource_type": resource_type,
                 "resources": resources,
                 "search_params": search_params,
-                "created_at": datetime.now().isoformat(),
-                "truncated": truncated
+                "created_at": progress.started_at.isoformat(),
+                "truncated": truncated,
+                "status": progress.status,
+                "build_time_ms": progress.build_time_ms,
+                "warnings": []
             }
             
             await self.cache_manager.store_dataset(cache_key, dataset, config.cache_ttl_seconds)
-            progress.complete(len(resources), truncated)
             
             logger.info(f"Dataset build complete: {dataset_id} ({len(resources)} resources, "
                        f"{progress.build_time_ms}ms, truncated={truncated})")
@@ -152,19 +162,7 @@ class AggregationService:
     async def get_dataset_slice(self, dataset_id: str, offset: int, limit: int, 
                                user_id: str) -> Dict[str, Any]:
         """Get paginated slice of cached dataset"""
-        
-        # Find dataset in cache by scanning user's datasets
-        cache_keys = await self.cache_manager.get_user_datasets(user_id)
-        dataset = None
-        
-        for cache_key in cache_keys:
-            cached = await self.cache_manager.get_dataset(cache_key)
-            if cached and cached["dataset_id"] == dataset_id:
-                dataset = cached
-                break
-        
-        if not dataset:
-            raise ValueError(f"Dataset not found: {dataset_id}")
+        dataset = await self._get_dataset_record(dataset_id, user_id)
         
         resources = dataset["resources"]
         total = len(resources)
@@ -186,6 +184,73 @@ class AggregationService:
             "has_prev": offset > 0,
             "truncated": dataset.get("truncated", False)
         }
+
+    async def get_dataset_profile(self, dataset_id: str, user_id: str) -> Dict[str, Any]:
+        """Return proposal-aligned metadata for a cached aggregate dataset."""
+        dataset = await self._get_dataset_record(dataset_id, user_id)
+        progress = self.progress_tracking.get(dataset_id)
+
+        status = dataset.get("status") or ("truncated" if dataset.get("truncated", False) else "ready")
+        progress_percent = 100
+        build_time_ms = dataset.get("build_time_ms", 0)
+
+        if progress:
+            progress_data = progress.to_dict()
+            status = progress_data.get("status", status)
+            build_time_ms = progress_data.get("build_time_ms", build_time_ms)
+            progress_percent = progress_data.get("progress_percent", progress_percent)
+
+        if status != "building":
+            progress_percent = 100
+
+        return {
+            "success": True,
+            "dataset_id": dataset_id,
+            "source_id": dataset.get("source_id", "default"),
+            "resource_type": dataset["resource_type"],
+            "status": status,
+            "progress_percent": progress_percent,
+            "total_records": len(dataset["resources"]),
+            "truncated": dataset.get("truncated", False),
+            "build_time_ms": build_time_ms,
+            "created_at": dataset.get("created_at"),
+            "warnings": dataset.get("warnings", [])
+        }
+
+    async def get_dataset_schema(self, dataset_id: str, user_id: str) -> Dict[str, Any]:
+        """Infer a lightweight schema summary for a cached aggregate dataset."""
+        dataset = await self._get_dataset_record(dataset_id, user_id)
+        resources = dataset.get("resources", [])
+
+        if not resources:
+            return {
+                "success": True,
+                "dataset_id": dataset_id,
+                "resource_type": dataset["resource_type"],
+                "flatten_profile": "default",
+                "columns": [],
+                "sampled_records": 0,
+                "warnings": [f"No cached {dataset['resource_type']} resources are available for schema inference."]
+            }
+
+        sampled_resources = resources[:self.SCHEMA_SAMPLE_SIZE]
+        column_paths = infer_columns(sampled_resources, max_paths=200)
+        warnings = []
+
+        if len(resources) > len(sampled_resources):
+            warnings.append(
+                f"Schema inferred from the first {len(sampled_resources)} resources out of {len(resources)} cached resources."
+            )
+
+        return {
+            "success": True,
+            "dataset_id": dataset_id,
+            "resource_type": dataset["resource_type"],
+            "flatten_profile": "default",
+            "columns": [self._build_column_definition(sampled_resources, path) for path in column_paths],
+            "sampled_records": len(sampled_resources),
+            "warnings": warnings
+        }
     
     async def get_progress(self, dataset_id: str) -> Optional[Dict[str, Any]]:
         """Get progress information for dataset build"""
@@ -204,6 +269,86 @@ class AggregationService:
                 return True
         
         return False
+
+    async def _get_dataset_record(self, dataset_id: str, user_id: str) -> Dict[str, Any]:
+        """Find a cached dataset record for the given user."""
+        cache_keys = await self.cache_manager.get_user_datasets(user_id)
+
+        for cache_key in cache_keys:
+            cached = await self.cache_manager.get_dataset(cache_key)
+            if cached and cached["dataset_id"] == dataset_id:
+                return cached
+
+        raise ValueError(f"Dataset not found: {dataset_id}")
+
+    def _build_column_definition(self, resources: List[Dict[str, Any]], path: str) -> Dict[str, Any]:
+        """Build a stable column metadata object from sampled resources."""
+        analysis = analyze_sample_values(resources, path)
+        sample_values = analysis.get("sample_values", [])
+
+        example_values: List[str] = []
+        seen = set()
+        for value in sample_values:
+            rendered = self._stringify_sample_value(value)
+            if rendered and rendered not in seen:
+                seen.add(rendered)
+                example_values.append(rendered)
+            if len(example_values) >= 3:
+                break
+
+        return {
+            "name": path,
+            "path": path,
+            "inferred_type": self._infer_logical_type(sample_values, path),
+            "nullable": analysis.get("sample_count", 0) < len(resources),
+            "repeated": "[" in path or any(isinstance(value, list) for value in sample_values),
+            "example_values": example_values
+        }
+
+    def _infer_logical_type(self, sample_values: List[Any], path: str) -> str:
+        """Infer a coarse logical type for a sampled column."""
+        non_null_values = [value for value in sample_values if value is not None]
+
+        if not non_null_values:
+            return "date" if self._looks_like_date_path(path) else "string"
+        if any(isinstance(value, list) for value in non_null_values):
+            return "array"
+        if any(isinstance(value, dict) for value in non_null_values):
+            return "object"
+        if all(isinstance(value, bool) for value in non_null_values):
+            return "boolean"
+        if all(isinstance(value, (int, float)) and not isinstance(value, bool) for value in non_null_values):
+            return "number"
+        if all(isinstance(value, str) for value in non_null_values):
+            if all(self._looks_like_date_value(value) for value in non_null_values):
+                return "date"
+
+        return "date" if self._looks_like_date_path(path) else "string"
+
+    def _looks_like_date_path(self, path: str) -> bool:
+        """Use common FHIR date/time field names as a fallback type hint."""
+        return any(token in path.lower() for token in ("date", "time", "issued", "effective", "recorded"))
+
+    def _looks_like_date_value(self, value: str) -> bool:
+        """Check whether a string resembles a FHIR date or datetime."""
+        candidate = value.strip()
+        if not candidate:
+            return False
+
+        if re.fullmatch(r"\d{4}(-\d{2}){0,2}", candidate):
+            return True
+
+        try:
+            datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+            return True
+        except ValueError:
+            return False
+
+    def _stringify_sample_value(self, value: Any) -> str:
+        """Convert example values to stable strings for API responses."""
+        if isinstance(value, (dict, list)):
+            return json.dumps(value, sort_keys=True)
+        return str(value)
     
     async def _fetch_all_resources(self, resource_type: str, search_params: Dict[str, Any],
                                   progress: AggregationProgress) -> Tuple[List[Dict], bool]:

--- a/fhir-backend-dynamic/app/services/cache_manager.py
+++ b/fhir-backend-dynamic/app/services/cache_manager.py
@@ -90,7 +90,7 @@ class MemoryCacheBackend(CacheBackend):
     
     async def get_keys_for_user(self, user_id: str) -> List[str]:
         async with self._lock:
-            return [key for key in self._cache.keys() if self._extract_user_from_key(key) == user_id]
+            return self._get_keys_for_user_unlocked(user_id)
     
     async def clear_expired(self) -> int:
         async with self._lock:
@@ -117,15 +117,19 @@ class MemoryCacheBackend(CacheBackend):
         """Extract user ID from cache key format: env:serverId:userId:resourceType:filterHash"""
         parts = key.split(":")
         return parts[2] if len(parts) >= 3 else None
+
+    def _get_keys_for_user_unlocked(self, user_id: str) -> List[str]:
+        """Get user-specific cache keys while the caller holds the lock."""
+        return [key for key in self._cache.keys() if self._extract_user_from_key(key) == user_id]
     
     async def _enforce_user_limits(self, user_id: str):
         """Enforce max datasets per user using LRU eviction"""
-        user_keys = await self.get_keys_for_user(user_id)
+        user_keys = self._get_keys_for_user_unlocked(user_id)
         
         if len(user_keys) >= self.max_datasets_per_user:
             # Sort by access time, evict oldest
             user_keys.sort(key=lambda k: self._access_order.get(k, datetime.min))
-            keys_to_remove = user_keys[:-self.max_datasets_per_user + 1]
+            keys_to_remove = user_keys[:len(user_keys) - self.max_datasets_per_user + 1]
             
             for key in keys_to_remove:
                 await self._remove_key(key)

--- a/fhir-backend-dynamic/tests/test_aggregation.py
+++ b/fhir-backend-dynamic/tests/test_aggregation.py
@@ -33,9 +33,11 @@ class TestAggregationService:
         """Mock cache manager"""
         mock_manager = MagicMock()
         mock_manager.generate_cache_key.return_value = "test:server:user123:Patient:hash123"
-        mock_manager.get_dataset.return_value = None
-        mock_manager.store_dataset.return_value = True
+        mock_manager.get_dataset = AsyncMock(return_value=None)
+        mock_manager.store_dataset = AsyncMock(return_value=True)
         mock_manager.get_dataset_id.return_value = "dataset-123"
+        mock_manager.get_user_datasets = AsyncMock(return_value=[])
+        mock_manager.delete_dataset = AsyncMock(return_value=True)
         return mock_manager
     
     @pytest.fixture
@@ -45,7 +47,7 @@ class TestAggregationService:
             service = AggregationService()
             return service
     
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_build_dataset_success(self, aggregation_service, mock_config):
         """Test successful dataset building"""
         # Mock FHIR responses
@@ -73,7 +75,7 @@ class TestAggregationService:
         assert result["cache_hit"] is False
         assert "build_time_ms" in result
     
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_build_dataset_with_pagination(self, aggregation_service, mock_config):
         """Test dataset building with multiple pages"""
         # Mock first page
@@ -110,7 +112,7 @@ class TestAggregationService:
         assert result["total"] == 15
         assert result["truncated"] is False
     
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_build_dataset_cache_hit(self, aggregation_service, mock_cache_manager):
         """Test cache hit scenario"""
         # Mock cached dataset
@@ -131,7 +133,7 @@ class TestAggregationService:
         assert result["cache_hit"] is True
         assert result["build_time_ms"] == 0
     
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_build_dataset_truncated(self, aggregation_service, mock_config):
         """Test dataset truncation at max records"""
         mock_config.aggregate_max_records = 5  # Small limit for testing
@@ -157,7 +159,7 @@ class TestAggregationService:
         assert result["total"] == 5  # Truncated to limit
         assert result["truncated"] is True
     
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_dataset_slice(self, aggregation_service, mock_cache_manager):
         """Test getting dataset slice"""
         # Mock dataset with multiple items
@@ -192,7 +194,7 @@ class TestAggregationService:
         assert result["items"][0]["id"] == "patient-5"
         assert result["items"][-1]["id"] == "patient-14"
     
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_dataset_slice_not_found(self, aggregation_service, mock_cache_manager):
         """Test slice request for non-existent dataset"""
         mock_cache_manager.get_user_datasets.return_value = []
@@ -204,6 +206,85 @@ class TestAggregationService:
                 limit=10,
                 user_id="user123"
             )
+
+    @pytest.mark.anyio
+    async def test_get_dataset_profile(self, aggregation_service, mock_cache_manager):
+        """Test dataset profile metadata response."""
+        dataset = {
+            "dataset_id": "profile-test-123",
+            "source_id": "default",
+            "resource_type": "Observation",
+            "resources": [
+                {"resourceType": "Observation", "id": "obs-1"},
+                {"resourceType": "Observation", "id": "obs-2"}
+            ],
+            "created_at": "2026-03-31T10:00:00",
+            "build_time_ms": 321,
+            "status": "ready",
+            "truncated": False,
+            "warnings": []
+        }
+
+        mock_cache_manager.get_user_datasets.return_value = ["test:key"]
+        mock_cache_manager.get_dataset.return_value = dataset
+
+        result = await aggregation_service.get_dataset_profile(
+            dataset_id="profile-test-123",
+            user_id="user123"
+        )
+
+        assert result["success"] is True
+        assert result["dataset_id"] == "profile-test-123"
+        assert result["source_id"] == "default"
+        assert result["resource_type"] == "Observation"
+        assert result["status"] == "ready"
+        assert result["progress_percent"] == 100
+        assert result["total_records"] == 2
+        assert result["build_time_ms"] == 321
+
+    @pytest.mark.anyio
+    async def test_get_dataset_schema(self, aggregation_service, mock_cache_manager):
+        """Test dataset schema inference response."""
+        dataset = {
+            "dataset_id": "schema-test-123",
+            "resource_type": "Observation",
+            "resources": [
+                {
+                    "resourceType": "Observation",
+                    "id": "obs-1",
+                    "status": "final",
+                    "effectiveDateTime": "2026-03-31T09:12:00Z"
+                },
+                {
+                    "resourceType": "Observation",
+                    "id": "obs-2",
+                    "status": "preliminary",
+                    "effectiveDateTime": "2026-03-31T10:15:00Z"
+                }
+            ],
+            "truncated": False
+        }
+
+        mock_cache_manager.get_user_datasets.return_value = ["test:key"]
+        mock_cache_manager.get_dataset.return_value = dataset
+
+        result = await aggregation_service.get_dataset_schema(
+            dataset_id="schema-test-123",
+            user_id="user123"
+        )
+
+        assert result["success"] is True
+        assert result["dataset_id"] == "schema-test-123"
+        assert result["resource_type"] == "Observation"
+        assert result["sampled_records"] == 2
+        assert result["warnings"] == []
+
+        columns = {column["path"]: column for column in result["columns"]}
+        assert "id" in columns
+        assert "status" in columns
+        assert "effectiveDateTime" in columns
+        assert columns["effectiveDateTime"]["inferred_type"] == "date"
+        assert columns["status"]["example_values"] == ["final", "preliminary"]
 
 
 class TestAggregationProgress:
@@ -239,7 +320,7 @@ class TestAggregationProgress:
         assert progress.estimated_total == 150
         assert progress.completed_at is not None
         assert progress.truncated is True
-        assert progress.build_time_ms > 0
+        assert progress.build_time_ms >= 0
     
     def test_progress_error(self):
         """Test progress error state"""
@@ -308,7 +389,7 @@ class TestCacheManager:
         assert norm1["name"] == norm2["name"]
         assert norm1["active"] == norm2["active"]
     
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_memory_cache_basic_operations(self):
         """Test basic memory cache operations"""
         backend = MemoryCacheBackend(max_datasets_per_user=5)
@@ -331,7 +412,7 @@ class TestCacheManager:
         retrieved_after_delete = await backend.get("test:key")
         assert retrieved_after_delete is None
     
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_memory_cache_expiry(self):
         """Test cache TTL expiry"""
         backend = MemoryCacheBackend()
@@ -343,15 +424,15 @@ class TestCacheManager:
         retrieved = await backend.get("short:key")
         assert retrieved is None
     
-    @pytest.mark.asyncio  
+    @pytest.mark.anyio
     async def test_memory_cache_user_limits(self):
         """Test per-user dataset limits"""
         backend = MemoryCacheBackend(max_datasets_per_user=2)
         
         # Add datasets for same user
-        await backend.set("test:server:user1:Patient:hash1", {"id": 1}, 300)
-        await backend.set("test:server:user1:Observation:hash2", {"id": 2}, 300)
-        await backend.set("test:server:user1:Condition:hash3", {"id": 3}, 300)  # Should evict oldest
+        await asyncio.wait_for(backend.set("test:server:user1:Patient:hash1", {"id": 1}, 300), timeout=1)
+        await asyncio.wait_for(backend.set("test:server:user1:Observation:hash2", {"id": 2}, 300), timeout=1)
+        await asyncio.wait_for(backend.set("test:server:user1:Condition:hash3", {"id": 3}, 300), timeout=1)  # Should evict oldest
         
         # First dataset should be evicted
         first = await backend.get("test:server:user1:Patient:hash1")


### PR DESCRIPTION
## Summary

  This PR turns the existing aggregate prototype into a small but usable backend slice for dataset-style exploration.
  It fixes the cache issue that prevented reliable dataset writes, re-enables the aggregate router, and adds
  proposal-aligned metadata endpoints for dataset profile and schema inspection.

  ## Changes

  - fix a deadlock in the in-memory aggregate cache when enforcing per-user dataset limits
  - re-enable aggregate routes behind the existing backend config flag
  - add `GET /api/aggregate/{dataset_id}/profile`
  - add `GET /api/aggregate/{dataset_id}/schema`
  - persist dataset metadata needed for profile and schema responses
  - extend aggregation tests to cover cache behavior, profile responses, and schema inference

  ## Why

  The repository already had an aggregation path, but it was disabled and missing the metadata contract needed for
  the dataset-oriented workflow described in the proposal. This PR keeps the scope intentionally small while
  delivering a concrete proof of work toward that larger design.

  ## Testing

  - `PYTHONPATH=fhir-backend-dynamic .venv/bin/python -m pytest fhir-backend-dynamic/tests/test_aggregation.py`

  ## Follow-up

  - align aggregate route naming with the proposal’s `/api/datasets/*` contract
  - attach richer source metadata beyond the current default server source
  - connect frontend aggregate flows to the new profile and schema endpoints