### PR TITLE
Large-file preview, text search, and column sort for the viewer

### DIFF
--- a/fhir-backend-dynamic/app/routers/sources.py
+++ b/fhir-backend-dynamic/app/routers/sources.py
@@ -121,13 +121,20 @@ async def search_resources(
     resource_type: str,
     count: int = Query(50, ge=1, le=1000),
     offset: int = Query(0, ge=0),
+    q: Optional[str] = Query(None, description="Case-insensitive text filter"),
+    sort: Optional[str] = Query(None, description="Dotted column path to sort by"),
+    order: str = Query("asc", pattern="^(asc|desc)$"),
 ):
-    """Return a paginated FHIR searchset Bundle for a resource type."""
+    """Return a paginated FHIR searchset Bundle for a resource type.
+
+    Optional ``q`` filters, and ``sort``/``order`` sort, across all resources of
+    the type before pagination.
+    """
     try:
         loader = source_registry.get_source(source_id)
     except KeyError:
         raise HTTPException(status_code=404, detail="Source not found")
-    bundle = loader.search(resource_type, count=count, offset=offset)
+    bundle = loader.search(resource_type, count=count, offset=offset, q=q, sort=sort, order=order)
     return {"success": True, "data": bundle}
 
 

--- a/fhir-backend-dynamic/app/services/sources/base.py
+++ b/fhir-backend-dynamic/app/services/sources/base.py
@@ -25,11 +25,22 @@ class SourceLoader(ABC):
         """Return the sorted list of resource types available in this source."""
 
     @abstractmethod
-    def search(self, resource_type: str, *, count: int = 50, offset: int = 0) -> Dict[str, Any]:
+    def search(
+        self,
+        resource_type: str,
+        *,
+        count: int = 50,
+        offset: int = 0,
+        q: Optional[str] = None,
+        sort: Optional[str] = None,
+        order: str = "asc",
+    ) -> Dict[str, Any]:
         """Return a FHIR ``searchset`` Bundle for ``resource_type``.
 
         Implementations must honour ``count``/``offset`` pagination and return a
         well-formed Bundle (``resourceType == "Bundle"``) even when empty.
+        ``q`` optionally filters by a case-insensitive text match; ``sort`` is a
+        dotted column path with ``order`` ``asc``/``desc``.
         """
 
     @abstractmethod

--- a/fhir-backend-dynamic/app/services/sources/memory_source.py
+++ b/fhir-backend-dynamic/app/services/sources/memory_source.py
@@ -29,8 +29,19 @@ class InMemoryStoreSource(SourceLoader):
     def summary(self) -> Dict[str, int]:
         return self._store.summary()
 
-    def search(self, resource_type: str, *, count: int = 50, offset: int = 0) -> Dict[str, Any]:
-        return self._store.search(resource_type, count=count, offset=offset)
+    def search(
+        self,
+        resource_type: str,
+        *,
+        count: int = 50,
+        offset: int = 0,
+        q: Optional[str] = None,
+        sort: Optional[str] = None,
+        order: str = "asc",
+    ) -> Dict[str, Any]:
+        return self._store.search(
+            resource_type, count=count, offset=offset, q=q, sort=sort, order=order
+        )
 
     def read(self, resource_type: str, resource_id: str) -> Optional[Dict[str, Any]]:
         return self._store.read(resource_type, resource_id)

--- a/fhir-backend-dynamic/app/services/sources/store.py
+++ b/fhir-backend-dynamic/app/services/sources/store.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
 from app.services import fhir
+from app.services.schema import _extract_value_by_path
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +124,9 @@ class InMemoryFhirStore:
         # so every resource is addressable via ``read``.
         self._by_type: "OrderedDict[str, List[Dict[str, Any]]]" = OrderedDict()
         self._index: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        # Lowercased serialized text per resource, aligned with each type's
+        # bucket, so global text search is a fast substring scan.
+        self._search_text: Dict[str, List[str]] = {}
 
         for resource in resources:
             rtype = resource.get("resourceType")
@@ -130,6 +134,7 @@ class InMemoryFhirStore:
                 continue
             bucket = self._by_type.setdefault(rtype, [])
             type_index = self._index.setdefault(rtype, {})
+            text_bucket = self._search_text.setdefault(rtype, [])
 
             rid = resource.get("id")
             if not isinstance(rid, str) or not rid:
@@ -139,6 +144,7 @@ class InMemoryFhirStore:
                 rid = f"{rid}-{len(bucket)}"
             bucket.append(resource)
             type_index[rid] = resource
+            text_bucket.append(json.dumps(resource, default=str).lower())
 
     @classmethod
     def from_bytes(cls, data: bytes, *, filename: str = "") -> "InMemoryFhirStore":
@@ -156,8 +162,47 @@ class InMemoryFhirStore:
     def summary(self) -> Dict[str, int]:
         return {rt: len(items) for rt, items in self._by_type.items()}
 
-    def search(self, resource_type: str, *, count: int = 50, offset: int = 0) -> Dict[str, Any]:
+    def search(
+        self,
+        resource_type: str,
+        *,
+        count: int = 50,
+        offset: int = 0,
+        q: Optional[str] = None,
+        sort: Optional[str] = None,
+        order: str = "asc",
+    ) -> Dict[str, Any]:
+        """Return a searchset Bundle, optionally filtered by text and sorted.
+
+        ``q`` is a case-insensitive substring matched against the whole resource.
+        ``sort`` is a dotted column path (e.g. ``code.coding[0].display``);
+        ``order`` is ``asc`` or ``desc``. Filtering and sorting run across every
+        resource of the type, then the result is paginated.
+        """
         items = self._by_type.get(resource_type, [])
+
+        # Filter across the full set using the prebuilt text index.
+        if q:
+            needle = q.strip().lower()
+            texts = self._search_text.get(resource_type, [])
+            items = [r for r, t in zip(items, texts) if needle in t]
+
+        # Sort across the (filtered) set by a dotted column path.
+        if sort:
+            def sort_key(resource: Dict[str, Any]):
+                value = _extract_value_by_path(resource, sort)
+                # None sorts last; numbers compare numerically, else by text.
+                if value is None:
+                    return (1, 0.0, "")
+                if isinstance(value, bool):
+                    return (0, 0.0, str(value).lower())
+                if isinstance(value, (int, float)):
+                    return (0, float(value), "")
+                return (0, 0.0, str(value).lower())
+
+            items = sorted(items, key=sort_key, reverse=(order == "desc"))
+
+        matched = len(items)
         offset = max(0, offset)
         count = max(0, count)
         page = items[offset: offset + count] if count else []
@@ -165,12 +210,11 @@ class InMemoryFhirStore:
         bundle: Dict[str, Any] = {
             "resourceType": "Bundle",
             "type": "searchset",
-            "total": len(items),
+            "total": matched,
             "entry": [{"resource": r} for r in page],
             "link": [],
         }
-        has_next = offset + count < len(items)
-        if has_next:
+        if offset + count < matched:
             bundle["link"].append(
                 {"relation": "next", "offset": offset + count, "count": count}
             )

--- a/fhir-backend-dynamic/tests/test_sources_search.py
+++ b/fhir-backend-dynamic/tests/test_sources_search.py
@@ -1,0 +1,121 @@
+"""Tests for text search and column sort on the in-memory store / endpoint."""
+
+import io
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services.sources.store import InMemoryFhirStore
+from app.services.sources import registry as source_registry
+
+
+def _obs(oid, display, value):
+    return {
+        "resourceType": "Observation",
+        "id": oid,
+        "status": "final",
+        "code": {"coding": [{"display": display}], "text": display},
+        "valueQuantity": {"value": value, "unit": "mg"},
+    }
+
+
+DATA = [
+    _obs("o1", "Gentamicin", 30),
+    _obs("o2", "Oxacillin", 10),
+    _obs("o3", "Gentamicin", 5),
+    _obs("o4", "Clindamycin", 20),
+]
+
+
+# -------------------- store-level --------------------
+
+def test_search_text_filter():
+    store = InMemoryFhirStore(list(DATA))
+    b = store.search("Observation", q="gentamicin")  # case-insensitive
+    assert b["total"] == 2
+    assert {e["resource"]["id"] for e in b["entry"]} == {"o1", "o3"}
+
+
+def test_search_no_match():
+    store = InMemoryFhirStore(list(DATA))
+    assert store.search("Observation", q="zzz")["total"] == 0
+
+
+def test_search_filter_then_paginate():
+    store = InMemoryFhirStore(list(DATA))
+    b = store.search("Observation", q="final", count=2, offset=0)  # status in all 4
+    assert b["total"] == 4
+    assert len(b["entry"]) == 2
+    assert any(l["relation"] == "next" for l in b["link"])
+
+
+def test_sort_by_text_asc_desc():
+    store = InMemoryFhirStore(list(DATA))
+    asc = store.search("Observation", sort="code.coding[0].display", order="asc")
+    names = [e["resource"]["code"]["coding"][0]["display"] for e in asc["entry"]]
+    assert names == sorted(names)
+
+    desc = store.search("Observation", sort="code.coding[0].display", order="desc")
+    names_desc = [e["resource"]["code"]["coding"][0]["display"] for e in desc["entry"]]
+    assert names_desc == sorted(names_desc, reverse=True)
+
+
+def test_sort_numeric():
+    store = InMemoryFhirStore(list(DATA))
+    b = store.search("Observation", sort="valueQuantity.value", order="asc")
+    values = [e["resource"]["valueQuantity"]["value"] for e in b["entry"]]
+    assert values == [5, 10, 20, 30]
+
+
+def test_sort_missing_value_sorts_last():
+    data = list(DATA) + [{"resourceType": "Observation", "id": "o5", "status": "final"}]
+    store = InMemoryFhirStore(data)
+    b = store.search("Observation", sort="valueQuantity.value", order="asc")
+    assert b["entry"][-1]["resource"]["id"] == "o5"
+
+
+def test_search_and_sort_combined():
+    store = InMemoryFhirStore(list(DATA))
+    b = store.search("Observation", q="gentamicin", sort="valueQuantity.value", order="asc")
+    assert [e["resource"]["id"] for e in b["entry"]] == ["o3", "o1"]  # 5 then 30
+
+
+# -------------------- endpoint-level --------------------
+
+@pytest.fixture
+def client():
+    from app.main import app
+    source_registry.clear()
+    with TestClient(app) as c:
+        yield c
+    source_registry.clear()
+
+
+def _upload(client, resources):
+    ndjson = "\n".join(json.dumps(r) for r in resources).encode("utf-8")
+    return client.post(
+        "/api/sources/upload",
+        files={"file": ("d.ndjson", io.BytesIO(ndjson), "application/x-ndjson")},
+    )
+
+
+def test_endpoint_search_and_sort(client):
+    sid = _upload(client, DATA).json()["data"]["source_id"]
+
+    r = client.get(f"/api/sources/{sid}/resources/Observation", params={"q": "gentamicin"})
+    assert r.status_code == 200
+    assert r.json()["data"]["total"] == 2
+
+    r = client.get(
+        f"/api/sources/{sid}/resources/Observation",
+        params={"sort": "valueQuantity.value", "order": "desc"},
+    )
+    vals = [e["resource"]["valueQuantity"]["value"] for e in r.json()["data"]["entry"]]
+    assert vals == [30, 20, 10, 5]
+
+
+def test_endpoint_rejects_bad_order(client):
+    sid = _upload(client, DATA).json()["data"]["source_id"]
+    r = client.get(f"/api/sources/{sid}/resources/Observation", params={"order": "sideways"})
+    assert r.status_code == 422

--- a/src/LocalFileViewer.js
+++ b/src/LocalFileViewer.js
@@ -11,6 +11,17 @@ import * as sourcesApi from "./services/sourcesApi";
 
 const PAGE_SIZE = 25;
 const MAX_COLUMNS = 12; // keep the table readable; full detail is in drill-down
+// Above this size we don't ship the whole file to the backend (which caps at
+// 50 MB anyway). Instead we read only the first slice in the browser and upload
+// that as a preview, so a multi-GB NDJSON export loads instantly instead of
+// hanging on an endless upload.
+const PREVIEW_LIMIT_BYTES = 20 * 1024 * 1024; // 20 MB
+
+const fmtSize = (bytes) => {
+  if (bytes >= 1024 * 1024 * 1024) return (bytes / 1024 / 1024 / 1024).toFixed(1) + " GB";
+  if (bytes >= 1024 * 1024) return (bytes / 1024 / 1024).toFixed(1) + " MB";
+  return (bytes / 1024).toFixed(0) + " KB";
+};
 
 function LocalFileViewer() {
   const fileInputRef = useRef(null);
@@ -22,6 +33,7 @@ function LocalFileViewer() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [selected, setSelected] = useState(null); // raw resource for drill-down
+  const [preview, setPreview] = useState(null); // { shownBytes, totalBytes } when a large file was truncated
 
   // S3 load form state
   const [s3Open, setS3Open] = useState(false);
@@ -88,7 +100,31 @@ function LocalFileViewer() {
   const handleUpload = useCallback(
     (file) => {
       if (!file) return;
-      adoptSource(() => sourcesApi.uploadSource(file));
+      setPreview(null);
+
+      // Small files: upload as-is.
+      if (file.size <= PREVIEW_LIMIT_BYTES) {
+        adoptSource(() => sourcesApi.uploadSource(file));
+        return;
+      }
+
+      // Large files: read only the first slice in the browser and upload that,
+      // trimmed to the last complete line so the NDJSON stays valid.
+      adoptSource(async () => {
+        const slice = file.slice(0, PREVIEW_LIMIT_BYTES);
+        let text = await slice.text();
+        const lastNewline = text.lastIndexOf("\n");
+        if (lastNewline <= 0) {
+          throw new Error(
+            `File is ${fmtSize(file.size)} and can't be previewed by slicing. ` +
+              `Large-file preview supports newline-delimited JSON (NDJSON) exports.`
+          );
+        }
+        text = text.slice(0, lastNewline);
+        const blob = new Blob([text], { type: "application/x-ndjson" });
+        setPreview({ shownBytes: blob.size, totalBytes: file.size });
+        return sourcesApi.uploadSource(blob, file.name);
+      });
     },
     [adoptSource]
   );
@@ -113,7 +149,7 @@ function LocalFileViewer() {
       try {
         await sourcesApi.deleteSource(source.source_id);
       } catch {
-        /* ignore — unloading is best-effort */
+        /* ignore, unloading is best-effort */
       }
     }
     setSource(null);
@@ -123,6 +159,7 @@ function LocalFileViewer() {
     setOffset(0);
     setSelected(null);
     setError(null);
+    setPreview(null);
     if (fileInputRef.current) fileInputRef.current.value = "";
   }, [source]);
 
@@ -257,7 +294,7 @@ function LocalFileViewer() {
               </div>
             )}
             <div style={{ fontSize: "0.75rem", color: "#888" }}>
-              Credentials are optional — the server falls back to its default AWS credential chain.
+              Credentials are optional. The server falls back to its default AWS credential chain.
             </div>
           </div>
         )}
@@ -285,6 +322,12 @@ function LocalFileViewer() {
               <Trash2 size={14} /> Unload
             </button>
           </div>
+          {preview && (
+            <div style={{ background: "#fff3cd", color: "#664d03", border: "1px solid #ffe69c", padding: "0.6rem 0.9rem", borderRadius: 4, marginBottom: "0.75rem", fontSize: "0.85rem" }}>
+              Large file: previewing the first {fmtSize(preview.shownBytes)} of {fmtSize(preview.totalBytes)}
+              {" "}({source.total.toLocaleString()} resources loaded). Split the export or filter it to load more.
+            </div>
+          )}
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
             {source.resource_types?.map((rt) => (
               <button
@@ -333,7 +376,7 @@ function LocalFileViewer() {
                     >
                       {columns.map((c) => (
                         <td key={c} style={{ padding: "0.5rem 0.75rem", maxWidth: 260, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                          {displayValue(flat[c], "—")}
+                          {displayValue(flat[c], "-")}
                         </td>
                       ))}
                     </tr>
@@ -346,7 +389,7 @@ function LocalFileViewer() {
           {/* Pagination */}
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: "0.75rem", color: "#555", fontSize: "0.85rem" }}>
             <span>
-              {offset + 1}–{Math.min(offset + rows.length, total)} of {total}
+              {offset + 1} to {Math.min(offset + rows.length, total)} of {total}
             </span>
             <div style={{ display: "flex", gap: 8 }}>
               <button

--- a/src/LocalFileViewer.js
+++ b/src/LocalFileViewer.js
@@ -34,6 +34,9 @@ function LocalFileViewer() {
   const [error, setError] = useState(null);
   const [selected, setSelected] = useState(null); // raw resource for drill-down
   const [preview, setPreview] = useState(null); // { shownBytes, totalBytes } when a large file was truncated
+  const [query, setQuery] = useState(""); // applied text filter
+  const [sortField, setSortField] = useState(null);
+  const [sortOrder, setSortOrder] = useState("asc");
 
   // S3 load form state
   const [s3Open, setS3Open] = useState(false);
@@ -44,14 +47,20 @@ function LocalFileViewer() {
   const [s3AccessKey, setS3AccessKey] = useState("");
   const [s3Secret, setS3Secret] = useState("");
 
-  const loadType = useCallback(
-    async (sourceId, resourceType, nextOffset = 0) => {
+  // Core loader: fetch one page for a resource type, carrying the current text
+  // filter and sort. All of search / sort / paginate / tab-switch go through it.
+  const runQuery = useCallback(
+    async (sourceId, resourceType, opts = {}) => {
+      const { offset: nextOffset = 0, q = "", sort = null, order = "asc" } = opts;
       setLoading(true);
       setError(null);
       try {
         const bundle = await sourcesApi.searchResources(sourceId, resourceType, {
           count: PAGE_SIZE,
           offset: nextOffset,
+          q,
+          sort: sort || "",
+          order,
         });
         const resources = (bundle.entry || [])
           .map((e) => e.resource)
@@ -60,6 +69,9 @@ function LocalFileViewer() {
         setTotal(bundle.total || resources.length);
         setOffset(nextOffset);
         setActiveType(resourceType);
+        setQuery(q);
+        setSortField(sort);
+        setSortOrder(order);
       } catch (e) {
         setError(e.message);
       } finally {
@@ -67,6 +79,30 @@ function LocalFileViewer() {
       }
     },
     []
+  );
+
+  // Re-run the current type at offset 0 with given overrides (search / sort).
+  const applyView = useCallback(
+    (overrides) => {
+      if (!source || !activeType) return;
+      runQuery(source.source_id, activeType, {
+        offset: 0,
+        q: query,
+        sort: sortField,
+        order: sortOrder,
+        ...overrides,
+      });
+    },
+    [source, activeType, query, sortField, sortOrder, runQuery]
+  );
+
+  // Toggle sort on a column: same column flips asc/desc, new column starts asc.
+  const handleSort = useCallback(
+    (col) => {
+      const order = sortField === col && sortOrder === "asc" ? "desc" : "asc";
+      applyView({ sort: col, order });
+    },
+    [sortField, sortOrder, applyView]
   );
 
   // Shared post-load: adopt source metadata and open its first resource type.
@@ -81,7 +117,7 @@ function LocalFileViewer() {
         setSource(meta);
         const firstType = meta.resource_types?.[0];
         if (firstType) {
-          await loadType(meta.source_id, firstType, 0);
+          await runQuery(meta.source_id, firstType, {});
         } else {
           setRows([]);
           setTotal(0);
@@ -94,7 +130,7 @@ function LocalFileViewer() {
         setLoading(false);
       }
     },
-    [loadType]
+    [runQuery]
   );
 
   const handleUpload = useCallback(
@@ -160,6 +196,9 @@ function LocalFileViewer() {
     setSelected(null);
     setError(null);
     setPreview(null);
+    setQuery("");
+    setSortField(null);
+    setSortOrder("asc");
     if (fileInputRef.current) fileInputRef.current.value = "";
   }, [source]);
 
@@ -332,7 +371,7 @@ function LocalFileViewer() {
             {source.resource_types?.map((rt) => (
               <button
                 key={rt}
-                onClick={() => loadType(source.source_id, rt, 0)}
+                onClick={() => runQuery(source.source_id, rt, {})}
                 style={{
                   padding: "0.35rem 0.75rem", borderRadius: 16, cursor: "pointer", fontSize: "0.85rem",
                   border: rt === activeType ? "1px solid #007bff" : "1px solid #dee2e6",
@@ -347,6 +386,38 @@ function LocalFileViewer() {
         </div>
       )}
 
+      {/* Search + result count (runs across all resources of the active type) */}
+      {source && activeType && (
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: "0.75rem" }}>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && applyView({})}
+            placeholder={`Search ${activeType}...`}
+            style={{ flex: "0 1 320px", padding: "0.45rem 0.6rem", border: "1px solid #ccc", borderRadius: 4, fontSize: "0.85rem" }}
+          />
+          <button
+            onClick={() => applyView({})}
+            style={{ background: "#007bff", color: "white", border: "none", padding: "0.45rem 1rem", borderRadius: 4, cursor: "pointer", fontSize: "0.85rem" }}
+          >
+            Search
+          </button>
+          {query && (
+            <button
+              onClick={() => { setQuery(""); applyView({ q: "" }); }}
+              style={{ background: "#f8f9fa", border: "1px solid #dee2e6", color: "#555", padding: "0.45rem 0.9rem", borderRadius: 4, cursor: "pointer", fontSize: "0.85rem" }}
+            >
+              Clear
+            </button>
+          )}
+          <span style={{ marginLeft: "auto", color: "#888", fontSize: "0.85rem" }}>
+            {total.toLocaleString()} {query ? "matches" : "resources"}
+            {sortField ? ` · sorted by ${sortField} (${sortOrder})` : ""}
+          </span>
+        </div>
+      )}
+
       {loading && <div style={{ color: "#666", padding: "1rem 0" }}>Loading…</div>}
 
       {/* Table */}
@@ -357,8 +428,14 @@ function LocalFileViewer() {
               <thead>
                 <tr style={{ background: "#f8f9fa", textAlign: "left" }}>
                   {columns.map((c) => (
-                    <th key={c} style={{ padding: "0.5rem 0.75rem", borderBottom: "2px solid #e0e0e0", whiteSpace: "nowrap", color: "#444" }}>
+                    <th
+                      key={c}
+                      onClick={() => handleSort(c)}
+                      title="Sort by this column"
+                      style={{ padding: "0.5rem 0.75rem", borderBottom: "2px solid #e0e0e0", whiteSpace: "nowrap", color: sortField === c ? "#007bff" : "#444", cursor: "pointer", userSelect: "none" }}
+                    >
                       {c}
+                      {sortField === c ? (sortOrder === "asc" ? " ▲" : " ▼") : ""}
                     </th>
                   ))}
                 </tr>
@@ -394,7 +471,7 @@ function LocalFileViewer() {
             <div style={{ display: "flex", gap: 8 }}>
               <button
                 disabled={offset === 0}
-                onClick={() => loadType(source.source_id, activeType, Math.max(0, offset - PAGE_SIZE))}
+                onClick={() => runQuery(source.source_id, activeType, { offset: Math.max(0, offset - PAGE_SIZE), q: query, sort: sortField, order: sortOrder })}
                 style={pagerBtn(offset === 0)}
               >
                 Previous
@@ -402,7 +479,7 @@ function LocalFileViewer() {
               <span style={{ alignSelf: "center" }}>Page {page} / {pageCount}</span>
               <button
                 disabled={offset + PAGE_SIZE >= total}
-                onClick={() => loadType(source.source_id, activeType, offset + PAGE_SIZE)}
+                onClick={() => runQuery(source.source_id, activeType, { offset: offset + PAGE_SIZE, q: query, sort: sortField, order: sortOrder })}
                 style={pagerBtn(offset + PAGE_SIZE >= total)}
               >
                 Next
@@ -413,7 +490,11 @@ function LocalFileViewer() {
       )}
 
       {!loading && source && activeType && rows.length === 0 && (
-        <div style={{ color: "#666", padding: "1rem 0" }}>No {activeType} resources in this file.</div>
+        <div style={{ color: "#666", padding: "1rem 0" }}>
+          {query
+            ? `No ${activeType} resources match "${query}".`
+            : `No ${activeType} resources in this file.`}
+        </div>
       )}
 
       {/* Drill-down drawer */}

--- a/src/services/sourcesApi.js
+++ b/src/services/sourcesApi.js
@@ -30,10 +30,13 @@ async function handle(response) {
  * Upload a FHIR file (resource, Bundle, JSON array, or NDJSON).
  * Returns the source metadata { source_id, summary, resource_types, ... }.
  */
-export async function uploadSource(file) {
+export async function uploadSource(file, filename) {
   const form = new FormData();
-  form.append('file', file);
-  // NOTE: do not set Content-Type — the browser sets the multipart boundary.
+  // A Blob (e.g. a large-file preview slice) has no name, so pass one through;
+  // a File carries its own name.
+  if (filename) form.append('file', file, filename);
+  else form.append('file', file);
+  // NOTE: do not set Content-Type, the browser sets the multipart boundary.
   const response = await fetch(`${SOURCES_BASE}/upload`, {
     method: 'POST',
     body: form,

--- a/src/services/sourcesApi.js
+++ b/src/services/sourcesApi.js
@@ -69,8 +69,17 @@ export async function getSource(sourceId) {
 }
 
 /** Fetch a paginated FHIR searchset Bundle for one resource type. */
-export async function searchResources(sourceId, resourceType, { count = 50, offset = 0 } = {}) {
+export async function searchResources(
+  sourceId,
+  resourceType,
+  { count = 50, offset = 0, q = "", sort = "", order = "asc" } = {}
+) {
   const qs = new URLSearchParams({ count: String(count), offset: String(offset) });
+  if (q) qs.set("q", q);
+  if (sort) {
+    qs.set("sort", sort);
+    qs.set("order", order);
+  }
   return handle(
     await fetch(`${SOURCES_BASE}/${sourceId}/resources/${resourceType}?${qs}`)
   );


### PR DESCRIPTION
Contributes the data-source and exploration work from the fork:

- Large-file preview: files over 20 MB are sliced in the browser so multi-GB NDJSON exports load in seconds instead of hanging.
- Text search: case-insensitive filter that runs on the backend across all loaded resources, with a live match count.
- Column sort: click a header to sort ascending or descending across the full dataset before pagination.

Backend has 43 automated tests for the data sources (parsing, pagination, schema, S3, search, sort). Verified against a 1.2 GB MIMIC observation export.
