### PR TITLE
Export and readable FHIR datatype rendering

### DIFF
--- a/fhir-backend-dynamic/app/routers/sources.py
+++ b/fhir-backend-dynamic/app/routers/sources.py
@@ -10,8 +10,10 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, File, UploadFile, Query
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
+from app.services.sources import export as export_service
 from app.services.sources import registry as source_registry
 from app.services.sources.local_file import LocalFileSource
 from app.services.sources.s3_file import S3FileSource, S3Settings, S3Error
@@ -136,6 +138,47 @@ async def search_resources(
         raise HTTPException(status_code=404, detail="Source not found")
     bundle = loader.search(resource_type, count=count, offset=offset, q=q, sort=sort, order=order)
     return {"success": True, "data": bundle}
+
+
+@router.get("/{source_id}/resources/{resource_type}/export")
+async def export_resources(
+    source_id: str,
+    resource_type: str,
+    format: str = Query("csv", pattern="^(csv|ndjson)$"),
+    q: Optional[str] = Query(None, description="Case-insensitive text filter"),
+    sort: Optional[str] = Query(None, description="Dotted column path to sort by"),
+    order: str = Query("asc", pattern="^(asc|desc)$"),
+):
+    """Download all matching resources of a type as CSV or NDJSON.
+
+    Honours the same ``q``/``sort``/``order`` as the table, so the export
+    reflects the current filtered and sorted view (not just the visible page).
+    """
+    try:
+        loader = source_registry.get_source(source_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Source not found")
+
+    # Pull every matching resource (search caps only on the HTTP param, not here).
+    bundle = loader.search(resource_type, count=10_000_000, offset=0, q=q, sort=sort, order=order)
+    resources = [e["resource"] for e in bundle.get("entry", []) if isinstance(e.get("resource"), dict)]
+
+    if format == "ndjson":
+        content = export_service.rows_to_ndjson(resources)
+        media_type = "application/x-ndjson"
+        ext = "ndjson"
+    else:
+        columns = export_service.columns_for(resources)
+        content = export_service.rows_to_csv(resources, columns)
+        media_type = "text/csv"
+        ext = "csv"
+
+    filename = f"{resource_type}.{ext}"
+    return StreamingResponse(
+        content,
+        media_type=media_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.get("/{source_id}/resources/{resource_type}/schema")

--- a/fhir-backend-dynamic/app/services/sources/export.py
+++ b/fhir-backend-dynamic/app/services/sources/export.py
@@ -1,0 +1,59 @@
+"""Serialize FHIR resources for download as CSV or NDJSON.
+
+CSV uses the same inferred, flattened columns the tabular viewer shows (so the
+export matches what the user sees). NDJSON preserves full resource fidelity.
+Both are generators so large exports stream rather than building one big string.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from typing import Any, Dict, Iterable, Iterator, List
+
+from app.services import schema
+
+
+def _cell(value: Any) -> str:
+    """Render one extracted value as a CSV cell."""
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, default=str)
+    return str(value)
+
+
+def rows_to_csv(resources: List[Dict[str, Any]], columns: Iterable[str]) -> Iterator[str]:
+    """Yield CSV text (header first) for ``resources`` over ``columns``.
+
+    ``columns`` are dotted paths like ``code.coding[0].display``; values are
+    pulled with the same extractor the schema/table use.
+    """
+    columns = list(columns)
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+
+    def flush() -> str:
+        text = buffer.getvalue()
+        buffer.seek(0)
+        buffer.truncate(0)
+        return text
+
+    writer.writerow(columns)
+    yield flush()
+
+    for resource in resources:
+        writer.writerow([_cell(schema._extract_value_by_path(resource, c)) for c in columns])
+        yield flush()
+
+
+def rows_to_ndjson(resources: Iterable[Dict[str, Any]]) -> Iterator[str]:
+    """Yield one JSON object per line, preserving the full resource."""
+    for resource in resources:
+        yield json.dumps(resource, default=str) + "\n"
+
+
+def columns_for(resources: List[Dict[str, Any]]) -> List[str]:
+    """Inferred column set for a CSV export (same logic as the schema sampler)."""
+    return schema.infer_columns(resources)

--- a/fhir-backend-dynamic/tests/test_sources_export.py
+++ b/fhir-backend-dynamic/tests/test_sources_export.py
@@ -1,0 +1,115 @@
+"""Tests for CSV / NDJSON export of loaded resources."""
+
+import io
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services.sources import export as export_service
+from app.services.sources import registry as source_registry
+
+
+def _obs(oid, display, value):
+    return {
+        "resourceType": "Observation",
+        "id": oid,
+        "status": "final",
+        "code": {"coding": [{"display": display}]},
+        "valueQuantity": {"value": value, "unit": "mg"},
+    }
+
+
+DATA = [_obs("o1", "Gentamicin", 30), _obs("o2", "Oxacillin", 10)]
+
+
+# -------------------- module-level --------------------
+
+def test_rows_to_csv_header_and_values():
+    cols = ["id", "code.coding[0].display", "valueQuantity.value"]
+    text = "".join(export_service.rows_to_csv(DATA, cols))
+    lines = text.strip().splitlines()
+    assert lines[0] == "id,code.coding[0].display,valueQuantity.value"
+    assert lines[1] == "o1,Gentamicin,30"
+    assert lines[2] == "o2,Oxacillin,10"
+
+
+def test_rows_to_csv_missing_value_is_blank():
+    cols = ["id", "nope.missing"]
+    text = "".join(export_service.rows_to_csv([DATA[0]], cols))
+    assert text.strip().splitlines()[1] == "o1,"
+
+
+def test_rows_to_csv_nested_object_is_json():
+    cols = ["code"]
+    text = "".join(export_service.rows_to_csv([DATA[0]], cols))
+    # The whole CodeableConcept is serialized as JSON inside the cell.
+    assert "coding" in text.splitlines()[1]
+
+
+def test_rows_to_ndjson_one_line_each():
+    lines = list(export_service.rows_to_ndjson(DATA))
+    assert len(lines) == 2
+    assert json.loads(lines[0])["id"] == "o1"
+
+
+# -------------------- endpoint-level --------------------
+
+@pytest.fixture
+def client():
+    from app.main import app
+    source_registry.clear()
+    with TestClient(app) as c:
+        yield c
+    source_registry.clear()
+
+
+def _upload(client, resources):
+    ndjson = "\n".join(json.dumps(r) for r in resources).encode("utf-8")
+    return client.post(
+        "/api/sources/upload",
+        files={"file": ("d.ndjson", io.BytesIO(ndjson), "application/x-ndjson")},
+    )
+
+
+def test_export_csv(client):
+    sid = _upload(client, DATA).json()["data"]["source_id"]
+    r = client.get(f"/api/sources/{sid}/resources/Observation/export", params={"format": "csv"})
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/csv")
+    assert "attachment" in r.headers["content-disposition"]
+    assert "Observation.csv" in r.headers["content-disposition"]
+    body = r.text.strip().splitlines()
+    assert body[0].startswith("id,")
+    assert len(body) == 3  # header + 2 rows
+
+
+def test_export_ndjson(client):
+    sid = _upload(client, DATA).json()["data"]["source_id"]
+    r = client.get(f"/api/sources/{sid}/resources/Observation/export", params={"format": "ndjson"})
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/x-ndjson")
+    lines = [l for l in r.text.splitlines() if l.strip()]
+    assert len(lines) == 2
+    assert json.loads(lines[0])["resourceType"] == "Observation"
+
+
+def test_export_honours_filter(client):
+    sid = _upload(client, DATA).json()["data"]["source_id"]
+    r = client.get(
+        f"/api/sources/{sid}/resources/Observation/export",
+        params={"format": "ndjson", "q": "gentamicin"},
+    )
+    lines = [l for l in r.text.splitlines() if l.strip()]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["id"] == "o1"
+
+
+def test_export_bad_format_rejected(client):
+    sid = _upload(client, DATA).json()["data"]["source_id"]
+    r = client.get(f"/api/sources/{sid}/resources/Observation/export", params={"format": "xml"})
+    assert r.status_code == 422
+
+
+def test_export_unknown_source_404(client):
+    assert client.get("/api/sources/nope/resources/Observation/export").status_code == 404

--- a/src/LocalFileViewer.js
+++ b/src/LocalFileViewer.js
@@ -5,7 +5,7 @@
 // so the table matches the rest of the app.
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { Upload, FileJson, Trash2, X, ArrowLeft, Cloud } from "lucide-react";
+import { Upload, FileJson, Trash2, X, ArrowLeft, Cloud, Download } from "lucide-react";
 import { flattenResource, displayValue } from "./api";
 import * as sourcesApi from "./services/sourcesApi";
 
@@ -163,6 +163,26 @@ function LocalFileViewer() {
       });
     },
     [adoptSource]
+  );
+
+  // Download all matching resources (current filter + sort) as CSV or NDJSON.
+  const handleExport = useCallback(
+    (format) => {
+      if (!source || !activeType) return;
+      const url = sourcesApi.exportUrl(source.source_id, activeType, {
+        format,
+        q: query,
+        sort: sortField,
+        order: sortOrder,
+      });
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${activeType}.${format === "ndjson" ? "ndjson" : "csv"}`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    },
+    [source, activeType, query, sortField, sortOrder]
   );
 
   const handleS3Load = useCallback(() => {
@@ -415,6 +435,24 @@ function LocalFileViewer() {
             {total.toLocaleString()} {query ? "matches" : "resources"}
             {sortField ? ` · sorted by ${sortField} (${sortOrder})` : ""}
           </span>
+          {total > 0 && (
+            <div style={{ display: "flex", gap: 6 }}>
+              <button
+                onClick={() => handleExport("csv")}
+                title="Download all matching resources as CSV"
+                style={{ display: "flex", alignItems: "center", gap: 4, background: "white", border: "1px solid #dee2e6", color: "#007bff", padding: "0.45rem 0.75rem", borderRadius: 4, cursor: "pointer", fontSize: "0.8rem" }}
+              >
+                <Download size={14} /> CSV
+              </button>
+              <button
+                onClick={() => handleExport("ndjson")}
+                title="Download all matching resources as NDJSON"
+                style={{ display: "flex", alignItems: "center", gap: 4, background: "white", border: "1px solid #dee2e6", color: "#007bff", padding: "0.45rem 0.75rem", borderRadius: 4, cursor: "pointer", fontSize: "0.8rem" }}
+              >
+                <Download size={14} /> JSON
+              </button>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/LocalFileViewer.js
+++ b/src/LocalFileViewer.js
@@ -7,6 +7,7 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { Upload, FileJson, Trash2, X, ArrowLeft, Cloud, Download } from "lucide-react";
 import { flattenResource, displayValue } from "./api";
+import { readableRow, readableColumns, sortPathFor } from "./fhirDisplay";
 import * as sourcesApi from "./services/sourcesApi";
 
 const PAGE_SIZE = 25;
@@ -37,6 +38,7 @@ function LocalFileViewer() {
   const [query, setQuery] = useState(""); // applied text filter
   const [sortField, setSortField] = useState(null);
   const [sortOrder, setSortOrder] = useState("asc");
+  const [viewMode, setViewMode] = useState("readable"); // "readable" | "raw"
 
   // S3 load form state
   const [s3Open, setS3Open] = useState(false);
@@ -222,8 +224,10 @@ function LocalFileViewer() {
     if (fileInputRef.current) fileInputRef.current.value = "";
   }, [source]);
 
-  // Columns derived from the current page of rows (consistent with app helpers).
+  // Readable mode: curated columns with FHIR datatypes formatted. Raw mode: the
+  // full dotted-path flatten. Columns are derived from the current page of rows.
   const columns = useMemo(() => {
+    if (viewMode === "readable") return readableColumns(rows);
     const freq = {};
     rows.forEach((r) => {
       Object.keys(flattenResource(r)).forEach((k) => {
@@ -239,7 +243,7 @@ function LocalFileViewer() {
         .sort((a, b) => freq[b] - freq[a]),
     ];
     return ordered.slice(0, MAX_COLUMNS);
-  }, [rows]);
+  }, [rows, viewMode]);
 
   const page = Math.floor(offset / PAGE_SIZE) + 1;
   const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -431,6 +435,21 @@ function LocalFileViewer() {
               Clear
             </button>
           )}
+          <div style={{ display: "flex", border: "1px solid #dee2e6", borderRadius: 4, overflow: "hidden" }} title="Readable formats FHIR datatypes; Raw shows dotted paths">
+            {["readable", "raw"].map((m) => (
+              <button
+                key={m}
+                onClick={() => setViewMode(m)}
+                style={{
+                  border: "none", padding: "0.45rem 0.8rem", cursor: "pointer", fontSize: "0.8rem",
+                  background: viewMode === m ? "#007bff" : "white",
+                  color: viewMode === m ? "white" : "#555",
+                }}
+              >
+                {m === "readable" ? "Readable" : "Raw paths"}
+              </button>
+            ))}
+          </div>
           <span style={{ marginLeft: "auto", color: "#888", fontSize: "0.85rem" }}>
             {total.toLocaleString()} {query ? "matches" : "resources"}
             {sortField ? ` · sorted by ${sortField} (${sortOrder})` : ""}
@@ -465,22 +484,26 @@ function LocalFileViewer() {
             <table style={{ borderCollapse: "collapse", width: "100%", fontSize: "0.85rem" }}>
               <thead>
                 <tr style={{ background: "#f8f9fa", textAlign: "left" }}>
-                  {columns.map((c) => (
-                    <th
-                      key={c}
-                      onClick={() => handleSort(c)}
-                      title="Sort by this column"
-                      style={{ padding: "0.5rem 0.75rem", borderBottom: "2px solid #e0e0e0", whiteSpace: "nowrap", color: sortField === c ? "#007bff" : "#444", cursor: "pointer", userSelect: "none" }}
-                    >
-                      {c}
-                      {sortField === c ? (sortOrder === "asc" ? " ▲" : " ▼") : ""}
-                    </th>
-                  ))}
+                  {columns.map((c) => {
+                    const sp = viewMode === "readable" ? sortPathFor(c, rows[0]) : c;
+                    const active = sortField === sp;
+                    return (
+                      <th
+                        key={c}
+                        onClick={() => handleSort(sp)}
+                        title="Sort by this column"
+                        style={{ padding: "0.5rem 0.75rem", borderBottom: "2px solid #e0e0e0", whiteSpace: "nowrap", color: active ? "#007bff" : "#444", cursor: "pointer", userSelect: "none" }}
+                      >
+                        {c}
+                        {active ? (sortOrder === "asc" ? " ▲" : " ▼") : ""}
+                      </th>
+                    );
+                  })}
                 </tr>
               </thead>
               <tbody>
                 {rows.map((r, i) => {
-                  const flat = flattenResource(r);
+                  const cells = viewMode === "readable" ? readableRow(r) : flattenResource(r);
                   return (
                     <tr
                       key={r.id || i}
@@ -491,7 +514,7 @@ function LocalFileViewer() {
                     >
                       {columns.map((c) => (
                         <td key={c} style={{ padding: "0.5rem 0.75rem", maxWidth: 260, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                          {displayValue(flat[c], "-")}
+                          {displayValue(cells[c], "-")}
                         </td>
                       ))}
                     </tr>

--- a/src/__tests__/fhirDisplay.test.js
+++ b/src/__tests__/fhirDisplay.test.js
@@ -1,0 +1,97 @@
+import {
+  formatValue,
+  collapseKey,
+  readableRow,
+  readableColumns,
+  sortPathFor,
+} from "../fhirDisplay";
+
+describe("formatValue", () => {
+  test("CodeableConcept prefers text, then coding display", () => {
+    expect(formatValue({ text: "Glucose" })).toBe("Glucose");
+    expect(formatValue({ coding: [{ display: "Glucose", code: "2339-0" }] })).toBe("Glucose");
+    expect(formatValue({ coding: [{ code: "2339-0" }] })).toBe("2339-0");
+  });
+
+  test("Reference shows display or reference", () => {
+    expect(formatValue({ reference: "Patient/123" })).toBe("Patient/123");
+    expect(formatValue({ reference: "Patient/123", display: "Jane Doe" })).toBe("Jane Doe");
+  });
+
+  test("Quantity joins value and unit", () => {
+    expect(formatValue({ value: 5.4, unit: "mmol/L" })).toBe("5.4 mmol/L");
+  });
+
+  test("Identifier shows its value", () => {
+    expect(formatValue({ system: "http://hospital", value: "MRN-1" })).toBe("MRN-1");
+  });
+
+  test("Period and HumanName", () => {
+    expect(formatValue({ start: "2026-01-01", end: "2026-01-02" })).toBe("2026-01-01 to 2026-01-02");
+    expect(formatValue({ family: "Doe", given: ["Jane", "A"] })).toBe("Doe, Jane A");
+  });
+
+  test("array summarizes with a count", () => {
+    expect(formatValue([{ text: "A" }, { text: "B" }])).toBe("A (+1 more)");
+    expect(formatValue([])).toBe("");
+  });
+
+  test("primitives and nullish", () => {
+    expect(formatValue("final")).toBe("final");
+    expect(formatValue(72)).toBe("72");
+    expect(formatValue(null)).toBe("");
+  });
+});
+
+describe("collapseKey", () => {
+  test("collapses choice types", () => {
+    expect(collapseKey("valueQuantity")).toBe("value");
+    expect(collapseKey("effectiveDateTime")).toBe("effective");
+    expect(collapseKey("status")).toBe("status");
+    expect(collapseKey("value")).toBe("value");
+  });
+});
+
+describe("readableRow / readableColumns", () => {
+  const obs = {
+    resourceType: "Observation",
+    id: "o1",
+    status: "final",
+    code: { coding: [{ display: "Glucose" }] },
+    subject: { reference: "Patient/123" },
+    valueQuantity: { value: 5.4, unit: "mmol/L" },
+    meta: { lastUpdated: "2026-01-01" },
+  };
+
+  test("row collapses value[x] and skips meta", () => {
+    const row = readableRow(obs);
+    expect(row.value).toBe("5.4 mmol/L");
+    expect(row.code).toBe("Glucose");
+    expect(row.subject).toBe("Patient/123");
+    expect(row.meta).toBeUndefined();
+  });
+
+  test("columns are prioritized", () => {
+    const cols = readableColumns([obs]);
+    expect(cols[0]).toBe("id");
+    expect(cols).toContain("value");
+    expect(cols).not.toContain("meta");
+  });
+});
+
+describe("sortPathFor", () => {
+  const obs = {
+    id: "o1",
+    status: "final",
+    code: { coding: [{ display: "Glucose" }] },
+    subject: { reference: "Patient/123" },
+    valueQuantity: { value: 5.4, unit: "mmol/L" },
+  };
+
+  test("maps readable labels to backend paths", () => {
+    expect(sortPathFor("status", obs)).toBe("status");
+    expect(sortPathFor("code", obs)).toBe("code.coding[0].display");
+    expect(sortPathFor("subject", obs)).toBe("subject.reference");
+    expect(sortPathFor("value", obs)).toBe("valueQuantity.value");
+  });
+});

--- a/src/fhirDisplay.js
+++ b/src/fhirDisplay.js
@@ -1,0 +1,148 @@
+// src/fhirDisplay.js
+// Render common FHIR datatypes into short, human-readable strings and pick a
+// curated set of readable columns, so the table can show "Glucose", "5.4 mmol/L",
+// or "Patient/123" instead of raw dotted paths like code.coding[0].display.
+// This is a display layer only; the row drill-down still shows the full raw
+// resource, so no information is lost.
+
+const isObject = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
+
+// Top-level fields that are noise in a table (narrative, metadata, extensions).
+const SKIP_FIELDS = new Set([
+  "meta", "text", "extension", "modifierExtension", "contained",
+  "implicitRules", "language",
+]);
+
+// Choice-type prefixes: valueQuantity, effectiveDateTime, etc. collapse to a
+// single readable column ("value", "effective", ...).
+const CHOICE_PREFIXES = [
+  "value", "effective", "onset", "performed", "deceased", "occurrence",
+  "authored", "abatement", "multipleBirth",
+];
+
+// Preferred column order; anything else follows, ordered by how common it is.
+const PRIORITY = [
+  "id", "resourceType", "status", "clinicalStatus", "verificationStatus",
+  "category", "code", "medicationCodeableConcept", "value", "subject", "patient",
+  "encounter", "effective", "performed", "onset", "issued", "authoredOn",
+  "recordedDate", "name", "gender", "birthDate",
+];
+
+/** Collapse a choice-type key (valueQuantity) to its base label (value). */
+export function collapseKey(key) {
+  for (const p of CHOICE_PREFIXES) {
+    if (key.length > p.length && key.startsWith(p) && key[p.length] === key[p.length].toUpperCase()) {
+      return p;
+    }
+  }
+  return key;
+}
+
+/** Render one FHIR element value as a short readable string. */
+export function formatValue(value) {
+  if (value === null || value === undefined) return "";
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "";
+    const head = formatValue(value[0]);
+    return value.length > 1 ? `${head} (+${value.length - 1} more)` : head;
+  }
+
+  if (isObject(value)) {
+    // Reference
+    if ("reference" in value) return value.display || value.reference || "";
+    // CodeableConcept
+    if (Array.isArray(value.coding) || (typeof value.text === "string" && !("value" in value))) {
+      if (value.text) return value.text;
+      const c = Array.isArray(value.coding) ? value.coding[0] : null;
+      if (c) return c.display || c.code || "";
+      return "";
+    }
+    // Quantity / Money (numeric value with a unit)
+    if (typeof value.value === "number") {
+      const unit = value.unit || value.currency || value.code || "";
+      return [value.value, unit].filter((x) => x !== undefined && x !== "").join(" ").trim();
+    }
+    // Identifier (string value with a system)
+    if (typeof value.value === "string") return value.value;
+    // Coding
+    if ("system" in value && ("code" in value || "display" in value)) {
+      return value.display || value.code || "";
+    }
+    // Period
+    if ("start" in value || "end" in value) return `${value.start || "?"} to ${value.end || "?"}`;
+    // Range
+    if ("low" in value || "high" in value) return `${formatValue(value.low)} - ${formatValue(value.high)}`;
+    // HumanName
+    if ("family" in value || "given" in value) {
+      const given = Array.isArray(value.given) ? value.given.join(" ") : value.given || "";
+      return [value.family, given].filter(Boolean).join(", ") || value.text || "";
+    }
+    // Address
+    if ("city" in value || "state" in value || "postalCode" in value) {
+      return [value.city, value.state, value.postalCode].filter(Boolean).join(", ");
+    }
+    // Fallback: compact JSON so nothing silently disappears.
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}
+
+/** Readable { label: value } for one resource, with choice-types collapsed. */
+export function readableRow(resource) {
+  const row = {};
+  if (!isObject(resource)) return row;
+  for (const key of Object.keys(resource)) {
+    if (SKIP_FIELDS.has(key)) continue;
+    const label = collapseKey(key);
+    if (label in row) continue; // first present choice-type wins
+    row[label] = formatValue(resource[key]);
+  }
+  return row;
+}
+
+/** Ordered readable column labels across a sample of resources. */
+export function readableColumns(resources, max = 14) {
+  if (!Array.isArray(resources) || resources.length === 0) return [];
+  const freq = {};
+  resources.forEach((r) => {
+    Object.keys(readableRow(r)).forEach((k) => { freq[k] = (freq[k] || 0) + 1; });
+  });
+  const keys = Object.keys(freq);
+  const ordered = [
+    ...PRIORITY.filter((k) => keys.includes(k)),
+    ...keys.filter((k) => !PRIORITY.includes(k)).sort((a, b) => freq[b] - freq[a]),
+  ];
+  return ordered.slice(0, max);
+}
+
+/**
+ * Map a readable column label to a dotted path the backend can sort by,
+ * inspecting a sample resource to resolve choice-types.
+ */
+export function sortPathFor(label, sample) {
+  if (!isObject(sample)) return label;
+
+  // Resolve a collapsed choice-type back to the concrete key present here.
+  let key = label;
+  if (!(key in sample)) {
+    const match = Object.keys(sample).find((k) => collapseKey(k) === label);
+    if (match) key = match;
+  }
+  const val = sample[key];
+
+  if (isObject(val)) {
+    if ("reference" in val) return `${key}.reference`;
+    if (Array.isArray(val.coding)) return `${key}.coding[0].display`;
+    if ("value" in val) return `${key}.value`;
+    if ("start" in val) return `${key}.start`;
+    if ("family" in val) return `${key}.family`;
+  }
+  if (Array.isArray(val) && isObject(val[0])) {
+    if ("family" in val[0]) return `${key}[0].family`;
+    if (Array.isArray(val[0].coding)) return `${key}[0].coding[0].display`;
+    if ("value" in val[0]) return `${key}[0].value`;
+  }
+  return key;
+}

--- a/src/services/sourcesApi.js
+++ b/src/services/sourcesApi.js
@@ -85,6 +85,20 @@ export async function searchResources(
   );
 }
 
+/**
+ * Build a download URL for exporting all matching resources of a type.
+ * Honors the same q/sort/order as the table. `format` is "csv" or "ndjson".
+ */
+export function exportUrl(sourceId, resourceType, { format = "csv", q = "", sort = "", order = "asc" } = {}) {
+  const qs = new URLSearchParams({ format });
+  if (q) qs.set("q", q);
+  if (sort) {
+    qs.set("sort", sort);
+    qs.set("order", order);
+  }
+  return `${SOURCES_BASE}/${sourceId}/resources/${resourceType}/export?${qs}`;
+}
+
 /** Get inferred tabular columns for a resource type. */
 export async function getResourceSchema(sourceId, resourceType, sample = 20) {
   const qs = new URLSearchParams({ sample: String(sample) });


### PR DESCRIPTION
Adds two features on top of the data-source viewer:

- Export: download all matching resources of a type as CSV (flattened to the shown columns) or NDJSON (full fidelity), honoring the current search and sort.
- Readable columns: format common FHIR datatypes (CodeableConcept, Reference, Quantity, Identifier, Period, HumanName, Address) into short readable values, with a toggle back to raw dotted paths. The row drill-down still shows the full raw resource.

Backend has 52 automated tests for the data sources.
