### PR TITLE
Stream multi-GB files to a disk-backed index, and column visibility

### DIFF
--- a/fhir-backend-dynamic/app/routers/sources.py
+++ b/fhir-backend-dynamic/app/routers/sources.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException, File, UploadFile, Query
 from fastapi.responses import StreamingResponse
+from starlette.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
 from app.services.sources import export as export_service
@@ -18,6 +19,10 @@ from app.services.sources import registry as source_registry
 from app.services.sources.local_file import LocalFileSource
 from app.services.sources.s3_file import S3FileSource, S3Settings, S3Error
 from app.services.sources.store import FhirParseError
+from app.services.sources.streaming_file import StreamingFileSource
+
+# Generous ceiling for streamed ingests; disk, not RAM, is the real limit.
+STREAM_MAX_RESOURCES = 5_000_000
 
 router = APIRouter(prefix="/sources", tags=["sources"])
 logger = logging.getLogger(__name__)
@@ -59,6 +64,41 @@ async def upload_source(file: UploadFile = File(...)):
     metadata = source_registry.add_source(loader, name=file.filename or "uploaded-file")
     logger.info(
         "Loaded source %s from %s (%d resources, %d types)",
+        metadata["source_id"], file.filename, metadata["total"],
+        len(metadata["resource_types"]),
+    )
+    return {"success": True, "data": metadata}
+
+
+@router.post("/upload/stream")
+async def upload_source_streaming(file: UploadFile = File(...)):
+    """Ingest a large NDJSON upload straight to disk, without buffering it.
+
+    Starlette spools the upload to a temp file, so this reads it line by line
+    into a SQLite-backed store. Peak memory stays flat regardless of file size,
+    which lets multi-GB bulk exports be browsed in full rather than previewed.
+    """
+    def _ingest() -> StreamingFileSource:
+        file.file.seek(0)
+        return StreamingFileSource.from_lines(
+            file.file,
+            filename=file.filename or "",
+            max_resources=STREAM_MAX_RESOURCES,
+        )
+
+    try:
+        loader = await run_in_threadpool(_ingest)
+    except FhirParseError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=422, detail="File is not valid UTF-8 text.")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("Unexpected error streaming upload %s", file.filename)
+        raise HTTPException(status_code=500, detail=f"Failed to ingest file: {exc}")
+
+    metadata = source_registry.add_source(loader, name=file.filename or "uploaded-file")
+    logger.info(
+        "Streamed source %s from %s (%d resources, %d types)",
         metadata["source_id"], file.filename, metadata["total"],
         len(metadata["resource_types"]),
     )

--- a/fhir-backend-dynamic/app/services/sources/base.py
+++ b/fhir-backend-dynamic/app/services/sources/base.py
@@ -51,6 +51,14 @@ class SourceLoader(ABC):
         """Return a ``{resource_type: count}`` map describing the source."""
         return {rt: self.count(rt) for rt in self.resource_types()}
 
+    def close(self) -> None:
+        """Release any resources held by this source.
+
+        In-memory sources need nothing; disk-backed ones override this to close
+        their database and delete temp files. Called when a source is unloaded.
+        """
+        return None
+
     @abstractmethod
     def count(self, resource_type: str) -> int:
         """Return the number of resources of ``resource_type`` in this source."""

--- a/fhir-backend-dynamic/app/services/sources/registry.py
+++ b/fhir-backend-dynamic/app/services/sources/registry.py
@@ -69,9 +69,23 @@ def list_sources() -> List[Dict[str, Any]]:
 
 def remove_source(source_id: str) -> bool:
     with _LOCK:
-        return _SOURCES.pop(source_id, None) is not None
+        entry = _SOURCES.pop(source_id, None)
+    if entry is None:
+        return False
+    # Let disk-backed sources drop their temp database.
+    try:
+        entry.loader.close()
+    except Exception:  # pragma: no cover - unloading is best-effort
+        pass
+    return True
 
 
 def clear() -> None:
     with _LOCK:
+        entries = list(_SOURCES.values())
         _SOURCES.clear()
+    for entry in entries:
+        try:
+            entry.loader.close()
+        except Exception:  # pragma: no cover - best-effort
+            pass

--- a/fhir-backend-dynamic/app/services/sources/sqlite_store.py
+++ b/fhir-backend-dynamic/app/services/sources/sqlite_store.py
@@ -1,0 +1,362 @@
+"""Disk-backed FHIR resource store for very large files.
+
+The in-memory store (:mod:`app.services.sources.store`) holds every resource
+plus a serialized text index in RAM, which does not survive a multi-GB export.
+This store instead streams resources into a SQLite database on disk as they are
+parsed, so peak memory stays flat no matter how large the input is, and answers
+search / sort / pagination as indexed SQL rather than Python loops.
+
+Two indexing strategies keep exploration interactive on files this size:
+
+* **Search** uses an FTS5 full-text index built during ingest, turning a
+  multi-second table scan into a sub-second lookup. Terms match whole words or
+  word prefixes (rather than arbitrary substrings); if FTS5 is unavailable in
+  the host SQLite build, it degrades to a ``LIKE`` scan automatically.
+* **Sort** builds an expression index over ``json_extract`` for a column the
+  first time that column is sorted, then reuses it. Sorting is paginated in two
+  segments (non-null values, then nulls) so missing values stay last while the
+  index still satisfies the ordering.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sqlite3
+import tempfile
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
+
+from app.services import fhir
+from app.services.sources.store import FhirParseError
+
+logger = logging.getLogger(__name__)
+
+# Rows per executemany batch during ingestion.
+BATCH_SIZE = 2000
+
+_INDEX_RE = re.compile(r"\[(\d+)\]")
+
+
+def dotted_to_jsonpath(path: str) -> str:
+    """Convert ``code.coding[0].display`` into SQLite's ``$.code.coding[0].display``.
+
+    Returns ``"$"`` for an empty path. Segments are passed through as-is;
+    json_extract simply yields NULL for anything that does not resolve.
+    """
+    path = (path or "").strip()
+    if not path:
+        return "$"
+    return "$." + path
+
+
+def _escape_like(needle: str) -> str:
+    """Escape LIKE wildcards so a literal substring search stays literal."""
+    return needle.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+_FTS_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+
+
+def build_fts_query(text: str) -> Optional[str]:
+    """Turn user input into a safe FTS5 MATCH expression, or None if unusable.
+
+    Each alphanumeric token becomes a quoted prefix term, so "genta cin" matches
+    documents containing a word starting with "genta" and one starting with
+    "cin". Returning None means the query has no searchable tokens.
+    """
+    tokens = _FTS_TOKEN_RE.findall(text or "")
+    if not tokens:
+        return None
+    return " AND ".join(f'"{t}"*' for t in tokens)
+
+
+def _iter_resources_from_lines(lines: Iterable[bytes]) -> Iterator[Dict[str, Any]]:
+    """Yield FHIR resources from an iterable of raw NDJSON lines.
+
+    Bundles are unwrapped, arrays are flattened, and blank lines are skipped, so
+    both bulk-export NDJSON and line-per-Bundle files stream correctly.
+    """
+    for lineno, raw in enumerate(lines, start=1):
+        if not raw:
+            continue
+        text = raw.decode("utf-8-sig", errors="strict").strip() if isinstance(raw, bytes) else raw.strip()
+        if not text:
+            continue
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise FhirParseError(
+                f"Streaming ingest expects newline-delimited JSON. "
+                f"Line {lineno} is not valid JSON: {exc}"
+            ) from exc
+
+        if isinstance(parsed, dict) and parsed.get("resourceType") == "Bundle":
+            for r in fhir.entries(parsed):
+                if isinstance(r, dict) and isinstance(r.get("resourceType"), str):
+                    yield r
+        elif isinstance(parsed, dict) and isinstance(parsed.get("resourceType"), str):
+            yield parsed
+        elif isinstance(parsed, list):
+            for r in parsed:
+                if isinstance(r, dict) and isinstance(r.get("resourceType"), str):
+                    yield r
+        else:
+            raise FhirParseError(f"Line {lineno} is valid JSON but is not a FHIR resource.")
+
+
+class SqliteFhirStore:
+    """A FHIR resource store backed by a SQLite file on disk."""
+
+    def __init__(self, db_path: Optional[str] = None):
+        if db_path is None:
+            fd, db_path = tempfile.mkstemp(prefix="fhir-source-", suffix=".sqlite")
+            os.close(fd)
+            self._owns_file = True
+        else:
+            self._owns_file = False
+        self.db_path = db_path
+
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        # This database is a disposable cache, so favour ingest speed over
+        # crash durability.
+        self._conn.execute("PRAGMA journal_mode = OFF")
+        self._conn.execute("PRAGMA synchronous = OFF")
+        self._conn.execute("PRAGMA temp_store = MEMORY")
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS resources ("
+            " rtype TEXT NOT NULL,"
+            " rid   TEXT NOT NULL,"
+            " seq   INTEGER NOT NULL,"
+            " body  TEXT NOT NULL)"
+        )
+        self._summary: Optional[Dict[str, int]] = None
+        self._fts_ready = False
+        self._sort_indexes: set = set()
+
+    # ------------------------------------------------------------------
+    # Ingestion
+    # ------------------------------------------------------------------
+
+    def ingest_lines(self, lines: Iterable[bytes], *, max_resources: Optional[int] = None) -> int:
+        """Stream NDJSON ``lines`` into the database. Returns the row count."""
+        counters: Dict[str, int] = {}
+        batch: List[Tuple[str, str, int, str]] = []
+        inserted = 0
+
+        for resource in _iter_resources_from_lines(lines):
+            rtype = resource["resourceType"]
+            seq = counters.get(rtype, 0)
+            counters[rtype] = seq + 1
+
+            rid = resource.get("id")
+            if not isinstance(rid, str) or not rid:
+                rid = f"_idx-{seq}"
+
+            batch.append((rtype, rid, seq, json.dumps(resource, default=str)))
+            if len(batch) >= BATCH_SIZE:
+                self._flush(batch)
+                inserted += len(batch)
+                batch = []
+
+            if max_resources is not None and inserted + len(batch) > max_resources:
+                raise FhirParseError(
+                    f"File contains more than {max_resources} resources."
+                )
+
+        if batch:
+            self._flush(batch)
+            inserted += len(batch)
+
+        if inserted == 0:
+            raise FhirParseError("No FHIR resources found in the uploaded file.")
+
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_rtype_seq ON resources(rtype, seq)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_rtype_rid ON resources(rtype, rid)")
+        self._conn.commit()
+        self._summary = None
+        self._build_fts()
+        logger.info("Streamed %d resources into %s", inserted, self.db_path)
+        return inserted
+
+    def _build_fts(self) -> None:
+        """Build the full-text index. Degrades to LIKE scans if unavailable."""
+        try:
+            self._conn.execute(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS fts "
+                "USING fts5(body, content='resources', content_rowid='rowid')"
+            )
+            self._conn.execute("INSERT INTO fts(fts) VALUES('rebuild')")
+            self._conn.commit()
+            self._fts_ready = True
+        except sqlite3.Error as exc:
+            logger.warning("FTS5 unavailable, falling back to LIKE search: %s", exc)
+            self._fts_ready = False
+
+    def _ensure_sort_index(self, jsonpath: str) -> None:
+        """Create an expression index for a sort column the first time it is used."""
+        if jsonpath in self._sort_indexes:
+            return
+        name = "idx_sort_" + re.sub(r"[^A-Za-z0-9]", "_", jsonpath)[:60]
+        try:
+            self._conn.execute(
+                f'CREATE INDEX IF NOT EXISTS "{name}" '
+                f"ON resources(rtype, json_extract(body, '{jsonpath}'))"
+            )
+            self._conn.commit()
+        except sqlite3.Error as exc:  # pragma: no cover - defensive
+            logger.warning("Could not index sort path %s: %s", jsonpath, exc)
+        self._sort_indexes.add(jsonpath)
+
+    def _flush(self, batch: List[Tuple[str, str, int, str]]) -> None:
+        self._conn.executemany(
+            "INSERT INTO resources (rtype, rid, seq, body) VALUES (?, ?, ?, ?)", batch
+        )
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def summary(self) -> Dict[str, int]:
+        if self._summary is None:
+            rows = self._conn.execute(
+                "SELECT rtype, COUNT(*) FROM resources GROUP BY rtype"
+            ).fetchall()
+            self._summary = {r[0]: r[1] for r in rows}
+        return dict(self._summary)
+
+    def resource_types(self) -> List[str]:
+        return sorted(self.summary().keys())
+
+    def count(self, resource_type: str) -> int:
+        return self.summary().get(resource_type, 0)
+
+    def total(self) -> int:
+        return sum(self.summary().values())
+
+    def _where(self, resource_type: str, q: Optional[str]) -> Tuple[str, list]:
+        """Build the WHERE clause, preferring the FTS index when one exists.
+
+        Returns a clause that always yields no rows when the query text has no
+        searchable tokens, so punctuation-only input cannot match everything.
+        """
+        clause = "WHERE rtype = ?"
+        params: list = [resource_type]
+        if q and q.strip():
+            if self._fts_ready:
+                match = build_fts_query(q)
+                if match is None:
+                    return clause + " AND 0", params
+                clause += " AND rowid IN (SELECT rowid FROM fts WHERE fts MATCH ?)"
+                params.append(match)
+            else:
+                clause += " AND body LIKE ? ESCAPE '\\'"
+                params.append(f"%{_escape_like(q.strip())}%")
+        return clause, params
+
+    def search(
+        self,
+        resource_type: str,
+        *,
+        count: int = 50,
+        offset: int = 0,
+        q: Optional[str] = None,
+        sort: Optional[str] = None,
+        order: str = "asc",
+    ) -> Dict[str, Any]:
+        """Return a FHIR searchset Bundle, filtered and sorted in SQL."""
+        where, params = self._where(resource_type, q)
+
+        matched = self._conn.execute(
+            f"SELECT COUNT(*) FROM resources {where}", params
+        ).fetchone()[0]
+
+        offset = max(0, offset)
+        count = max(0, count)
+
+        entries: List[Dict[str, Any]] = []
+        if count:
+            if sort:
+                bodies = self._sorted_page(where, params, sort, order, count, offset)
+            else:
+                bodies = [
+                    r[0]
+                    for r in self._conn.execute(
+                        f"SELECT body FROM resources {where} ORDER BY seq ASC LIMIT ? OFFSET ?",
+                        params + [count, offset],
+                    ).fetchall()
+                ]
+            entries = [{"resource": json.loads(b)} for b in bodies]
+
+        bundle: Dict[str, Any] = {
+            "resourceType": "Bundle",
+            "type": "searchset",
+            "total": matched,
+            "entry": entries,
+            "link": [],
+        }
+        if offset + count < matched:
+            bundle["link"].append({"relation": "next", "offset": offset + count, "count": count})
+        if offset > 0:
+            bundle["link"].append({"relation": "prev", "offset": max(0, offset - count), "count": count})
+        return bundle
+
+    def _sorted_page(
+        self, where: str, params: list, sort: str, order: str, count: int, offset: int
+    ) -> List[str]:
+        """Page through rows ordered by a JSON path, keeping missing values last.
+
+        Rows with a value are ordered by the indexed expression; rows where the
+        path is absent follow, ordered by ingest sequence. Splitting the two
+        keeps "nulls last" without an ORDER BY term that would defeat the index.
+        """
+        jp = dotted_to_jsonpath(sort)
+        self._ensure_sort_index(jp)
+        direction = "DESC" if order == "desc" else "ASC"
+        expr = f"json_extract(body, '{jp}')"
+
+        n_valued = self._conn.execute(
+            f"SELECT COUNT(*) FROM resources {where} AND {expr} IS NOT NULL", params
+        ).fetchone()[0]
+
+        bodies: List[str] = []
+        if offset < n_valued:
+            take = min(count, n_valued - offset)
+            rows = self._conn.execute(
+                f"SELECT body FROM resources {where} AND {expr} IS NOT NULL "
+                f"ORDER BY {expr} {direction}, seq ASC LIMIT ? OFFSET ?",
+                params + [take, offset],
+            ).fetchall()
+            bodies.extend(r[0] for r in rows)
+
+        # Fill the rest of the page from rows missing this path.
+        if len(bodies) < count:
+            null_offset = max(0, offset - n_valued)
+            rows = self._conn.execute(
+                f"SELECT body FROM resources {where} AND {expr} IS NULL "
+                f"ORDER BY seq ASC LIMIT ? OFFSET ?",
+                params + [count - len(bodies), null_offset],
+            ).fetchall()
+            bodies.extend(r[0] for r in rows)
+        return bodies
+
+    def read(self, resource_type: str, resource_id: str) -> Optional[Dict[str, Any]]:
+        """Return one resource by id (first match by ingest order), or None."""
+        row = self._conn.execute(
+            "SELECT body FROM resources WHERE rtype = ? AND rid = ? ORDER BY seq ASC LIMIT 1",
+            (resource_type, resource_id),
+        ).fetchone()
+        return json.loads(row[0]) if row else None
+
+    def close(self) -> None:
+        """Close the connection and delete the backing file if we created it."""
+        try:
+            self._conn.close()
+        except Exception:  # pragma: no cover - defensive
+            pass
+        if self._owns_file and self.db_path and os.path.exists(self.db_path):
+            try:
+                os.remove(self.db_path)
+            except OSError:  # pragma: no cover - defensive
+                logger.warning("Could not remove temp database %s", self.db_path)

--- a/fhir-backend-dynamic/app/services/sources/streaming_file.py
+++ b/fhir-backend-dynamic/app/services/sources/streaming_file.py
@@ -1,0 +1,71 @@
+"""A :class:`SourceLoader` backed by a disk-resident SQLite store.
+
+Used for very large uploads: resources are streamed into SQLite during ingest
+rather than held in memory, so a multi-GB NDJSON export can be browsed in full.
+Satisfies the same contract as the in-memory sources, so search, sort, schema,
+and export all work unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+
+from app.services.sources.base import SourceLoader
+from app.services.sources.sqlite_store import SqliteFhirStore
+
+
+class StreamingFileSource(SourceLoader):
+    """Serve FHIR resources from a disk-backed SQLite store."""
+
+    source_type = "streaming_file"
+
+    def __init__(self, store: SqliteFhirStore, *, filename: str = ""):
+        self._store = store
+        self.filename = filename
+
+    @classmethod
+    def from_lines(
+        cls,
+        lines: Iterable[bytes],
+        *,
+        filename: str = "",
+        max_resources: Optional[int] = None,
+    ) -> "StreamingFileSource":
+        """Ingest an iterable of NDJSON lines into a fresh disk store."""
+        store = SqliteFhirStore()
+        try:
+            store.ingest_lines(lines, max_resources=max_resources)
+        except Exception:
+            store.close()
+            raise
+        return cls(store, filename=filename)
+
+    def resource_types(self) -> List[str]:
+        return self._store.resource_types()
+
+    def count(self, resource_type: str) -> int:
+        return self._store.count(resource_type)
+
+    def summary(self) -> Dict[str, int]:
+        return self._store.summary()
+
+    def search(
+        self,
+        resource_type: str,
+        *,
+        count: int = 50,
+        offset: int = 0,
+        q: Optional[str] = None,
+        sort: Optional[str] = None,
+        order: str = "asc",
+    ) -> Dict[str, Any]:
+        return self._store.search(
+            resource_type, count=count, offset=offset, q=q, sort=sort, order=order
+        )
+
+    def read(self, resource_type: str, resource_id: str) -> Optional[Dict[str, Any]]:
+        return self._store.read(resource_type, resource_id)
+
+    def close(self) -> None:
+        """Release the SQLite connection and delete the temp database."""
+        self._store.close()

--- a/fhir-backend-dynamic/tests/test_sources_streaming.py
+++ b/fhir-backend-dynamic/tests/test_sources_streaming.py
@@ -1,0 +1,261 @@
+"""Tests for the disk-backed streaming store used for very large files."""
+
+import io
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services.sources import registry as source_registry
+from app.services.sources.sqlite_store import SqliteFhirStore, dotted_to_jsonpath
+from app.services.sources.store import FhirParseError
+from app.services.sources.streaming_file import StreamingFileSource
+
+
+def _obs(oid, display, value):
+    return {
+        "resourceType": "Observation",
+        "id": oid,
+        "status": "final",
+        "code": {"coding": [{"display": display}]},
+        "valueQuantity": {"value": value, "unit": "mg"},
+    }
+
+
+DATA = [
+    _obs("o1", "Gentamicin", 30),
+    _obs("o2", "Oxacillin", 10),
+    _obs("o3", "Vancomycin", 20),
+    {"resourceType": "Patient", "id": "p1", "name": [{"family": "Doe"}]},
+]
+
+
+def _lines(resources):
+    return [(json.dumps(r) + "\n").encode("utf-8") for r in resources]
+
+
+@pytest.fixture
+def store():
+    s = SqliteFhirStore()
+    yield s
+    s.close()
+
+
+# -------------------- path translation --------------------
+
+def test_dotted_to_jsonpath():
+    assert dotted_to_jsonpath("code.coding[0].display") == "$.code.coding[0].display"
+    assert dotted_to_jsonpath("status") == "$.status"
+    assert dotted_to_jsonpath("") == "$"
+
+
+# -------------------- ingestion --------------------
+
+def test_ingest_counts_and_types(store):
+    n = store.ingest_lines(_lines(DATA))
+    assert n == 4
+    assert store.resource_types() == ["Observation", "Patient"]
+    assert store.summary() == {"Observation": 3, "Patient": 1}
+    assert store.total() == 4
+
+
+def test_ingest_unwraps_bundles(store):
+    bundle = {
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": [{"resource": DATA[0]}, {"resource": DATA[3]}],
+    }
+    store.ingest_lines(_lines([bundle]))
+    assert store.summary() == {"Observation": 1, "Patient": 1}
+
+
+def test_ingest_skips_blank_lines(store):
+    raw = _lines(DATA[:2])
+    raw.insert(1, b"\n")
+    raw.append(b"   \n")
+    assert store.ingest_lines(raw) == 2
+
+
+def test_ingest_rejects_bad_json(store):
+    with pytest.raises(FhirParseError):
+        store.ingest_lines([b'{"resourceType":"Patient"}\n', b"{not json}\n"])
+
+
+def test_ingest_rejects_empty(store):
+    with pytest.raises(FhirParseError):
+        store.ingest_lines([b"\n", b"  \n"])
+
+
+def test_ingest_enforces_max_resources(store):
+    with pytest.raises(FhirParseError):
+        store.ingest_lines(_lines(DATA), max_resources=2)
+
+
+# -------------------- query --------------------
+
+def test_search_pagination_and_links(store):
+    store.ingest_lines(_lines(DATA))
+    b = store.search("Observation", count=2, offset=0)
+    assert b["total"] == 3
+    assert len(b["entry"]) == 2
+    assert any(l["relation"] == "next" for l in b["link"])
+    assert not any(l["relation"] == "prev" for l in b["link"])
+
+    b2 = store.search("Observation", count=2, offset=2)
+    assert len(b2["entry"]) == 1
+    assert any(l["relation"] == "prev" for l in b2["link"])
+
+
+def test_search_text_filter_is_case_insensitive(store):
+    store.ingest_lines(_lines(DATA))
+    b = store.search("Observation", q="gentamicin")
+    assert b["total"] == 1
+    assert b["entry"][0]["resource"]["id"] == "o1"
+
+
+def test_search_filter_no_match(store):
+    store.ingest_lines(_lines(DATA))
+    assert store.search("Observation", q="zzzz")["total"] == 0
+
+
+def test_search_wildcards_are_literal(store):
+    store.ingest_lines(_lines(DATA))
+    # Punctuation-only input has no searchable tokens, so it must match nothing
+    # rather than acting as a wildcard.
+    assert store.search("Observation", q="%")["total"] == 0
+    assert store.search("Observation", q='" OR 1=1 --')["total"] == 0
+
+
+def test_search_matches_word_prefix(store):
+    store.ingest_lines(_lines(DATA))
+    assert store.search("Observation", q="genta")["total"] == 1
+    assert store.search("Observation", q="GENTA")["total"] == 1
+
+
+def test_build_fts_query():
+    from app.services.sources.sqlite_store import build_fts_query
+    assert build_fts_query("genta") == '"genta"*'
+    assert build_fts_query("genta cin") == '"genta"* AND "cin"*'
+    assert build_fts_query("  %%  ") is None
+    assert build_fts_query("") is None
+
+
+def test_sort_numeric_and_text(store):
+    store.ingest_lines(_lines(DATA))
+    asc = store.search("Observation", sort="valueQuantity.value", order="asc")
+    assert [e["resource"]["valueQuantity"]["value"] for e in asc["entry"]] == [10, 20, 30]
+
+    desc = store.search("Observation", sort="code.coding[0].display", order="desc")
+    names = [e["resource"]["code"]["coding"][0]["display"] for e in desc["entry"]]
+    assert names == sorted(names, reverse=True)
+
+
+def test_sort_missing_values_last(store):
+    data = DATA[:3] + [{"resourceType": "Observation", "id": "o4", "status": "final"}]
+    store.ingest_lines(_lines(data))
+    b = store.search("Observation", sort="valueQuantity.value", order="asc")
+    assert b["entry"][-1]["resource"]["id"] == "o4"
+
+
+def test_search_and_sort_combined(store):
+    store.ingest_lines(_lines(DATA))
+    # Search matches word prefixes, so "van" finds Vancomycin only.
+    b = store.search("Observation", q="van", sort="valueQuantity.value", order="desc")
+    assert [e["resource"]["id"] for e in b["entry"]] == ["o3"]
+
+    # A term shared by several rows still sorts correctly.
+    b2 = store.search("Observation", q="final", sort="valueQuantity.value", order="desc")
+    assert [e["resource"]["id"] for e in b2["entry"]] == ["o1", "o3", "o2"]
+
+
+def test_read_by_id_and_missing(store):
+    store.ingest_lines(_lines(DATA))
+    assert store.read("Observation", "o2")["id"] == "o2"
+    assert store.read("Observation", "nope") is None
+
+
+def test_read_synthetic_id_for_missing_id(store):
+    store.ingest_lines(_lines([{"resourceType": "Patient", "name": [{"family": "X"}]}]))
+    assert store.read("Patient", "_idx-0") is not None
+
+
+def test_close_removes_temp_database():
+    s = SqliteFhirStore()
+    path = s.db_path
+    s.ingest_lines(_lines(DATA))
+    assert os.path.exists(path)
+    s.close()
+    assert not os.path.exists(path)
+
+
+def test_loader_schema_uses_shared_inference():
+    src = StreamingFileSource.from_lines(_lines(DATA))
+    try:
+        schema = src.schema("Observation", sample=10)
+        assert schema["total"] == 3
+        assert "id" in schema["columns"]
+        assert any("code.coding" in c for c in schema["columns"])
+    finally:
+        src.close()
+
+
+# -------------------- endpoint --------------------
+
+@pytest.fixture
+def client():
+    from app.main import app
+    source_registry.clear()
+    with TestClient(app) as c:
+        yield c
+    source_registry.clear()
+
+
+def _upload_stream(client, resources, name="big.ndjson"):
+    payload = b"".join(_lines(resources))
+    return client.post(
+        "/api/sources/upload/stream",
+        files={"file": (name, io.BytesIO(payload), "application/x-ndjson")},
+    )
+
+
+def test_stream_endpoint_full_flow(client):
+    r = _upload_stream(client, DATA)
+    assert r.status_code == 200, r.text
+    meta = r.json()["data"]
+    assert meta["source_type"] == "streaming_file"
+    assert meta["summary"] == {"Observation": 3, "Patient": 1}
+
+    sid = meta["source_id"]
+    # searchable
+    b = client.get(f"/api/sources/{sid}/resources/Observation", params={"q": "oxacillin"}).json()["data"]
+    assert b["total"] == 1
+    # sortable
+    b2 = client.get(
+        f"/api/sources/{sid}/resources/Observation",
+        params={"sort": "valueQuantity.value", "order": "desc"},
+    ).json()["data"]
+    assert b2["entry"][0]["resource"]["valueQuantity"]["value"] == 30
+    # exportable
+    exp = client.get(f"/api/sources/{sid}/resources/Observation/export", params={"format": "ndjson"})
+    assert len([l for l in exp.text.splitlines() if l.strip()]) == 3
+    # readable one by one
+    assert client.get(f"/api/sources/{sid}/resources/Observation/o1").status_code == 200
+
+
+def test_stream_endpoint_deletes_temp_file_on_unload(client):
+    sid = _upload_stream(client, DATA).json()["data"]["source_id"]
+    loader = source_registry.get_source(sid)
+    path = loader._store.db_path
+    assert os.path.exists(path)
+    assert client.delete(f"/api/sources/{sid}").status_code == 200
+    assert not os.path.exists(path)
+
+
+def test_stream_endpoint_rejects_bad_ndjson(client):
+    payload = b'{"resourceType":"Patient"}\n{oops}\n'
+    r = client.post(
+        "/api/sources/upload/stream",
+        files={"file": ("bad.ndjson", io.BytesIO(payload), "application/x-ndjson")},
+    )
+    assert r.status_code == 422

--- a/src/LocalFileViewer.js
+++ b/src/LocalFileViewer.js
@@ -3,7 +3,7 @@
 // backend /api/sources endpoints. Kept independent of the patient-centric flow
 // so it can't destabilize it. Reuses flattenResource/displayValue from api.js
 // so the table matches the rest of the app.
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { Upload, FileJson, Trash2, X, ArrowLeft, Cloud, Download } from "lucide-react";
 import { flattenResource, displayValue } from "./api";
@@ -39,6 +39,8 @@ function LocalFileViewer() {
   const [sortField, setSortField] = useState(null);
   const [sortOrder, setSortOrder] = useState("asc");
   const [viewMode, setViewMode] = useState("readable"); // "readable" | "raw"
+  const [visibleColumns, setVisibleColumns] = useState(null); // null = use defaults
+  const [columnsMenuOpen, setColumnsMenuOpen] = useState(false);
 
   // S3 load form state
   const [s3Open, setS3Open] = useState(false);
@@ -221,10 +223,10 @@ function LocalFileViewer() {
     if (fileInputRef.current) fileInputRef.current.value = "";
   }, [source]);
 
-  // Readable mode: curated columns with FHIR datatypes formatted. Raw mode: the
-  // full dotted-path flatten. Columns are derived from the current page of rows.
-  const columns = useMemo(() => {
-    if (viewMode === "readable") return readableColumns(rows);
+  // Every candidate column for the current rows and mode (full, uncapped).
+  // Readable mode: curated FHIR labels. Raw mode: all dotted paths.
+  const allColumns = useMemo(() => {
+    if (viewMode === "readable") return readableColumns(rows, 1000);
     const freq = {};
     rows.forEach((r) => {
       Object.keys(flattenResource(r)).forEach((k) => {
@@ -233,14 +235,39 @@ function LocalFileViewer() {
     });
     const keys = Object.keys(freq);
     const essential = ["id", "resourceType", "status", "code.text", "code.coding[0].display"];
-    const ordered = [
+    return [
       ...essential.filter((k) => keys.includes(k)),
       ...keys
         .filter((k) => !essential.includes(k))
         .sort((a, b) => freq[b] - freq[a]),
     ];
-    return ordered.slice(0, MAX_COLUMNS);
   }, [rows, viewMode]);
+
+  // Default subset shown before the user customizes visibility.
+  const defaultColumns = useMemo(
+    () => allColumns.slice(0, viewMode === "readable" ? 14 : MAX_COLUMNS),
+    [allColumns, viewMode]
+  );
+
+  // Reset any custom visibility when the type or view mode changes.
+  useEffect(() => {
+    setVisibleColumns(null);
+  }, [activeType, viewMode]);
+
+  const columns = visibleColumns ?? defaultColumns;
+
+  const toggleColumn = useCallback(
+    (col) => {
+      const base = new Set(visibleColumns ?? defaultColumns);
+      if (base.has(col)) base.delete(col);
+      else base.add(col);
+      // Keep the selection ordered like allColumns.
+      setVisibleColumns(allColumns.filter((c) => base.has(c)));
+    },
+    [visibleColumns, defaultColumns, allColumns]
+  );
+
+  const resetColumns = useCallback(() => setVisibleColumns(null), []);
 
   const page = Math.floor(offset / PAGE_SIZE) + 1;
   const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -447,6 +474,32 @@ function LocalFileViewer() {
               </button>
             ))}
           </div>
+          {allColumns.length > 0 && (
+            <div style={{ position: "relative" }}>
+              <button
+                onClick={() => setColumnsMenuOpen((v) => !v)}
+                style={{ background: "white", border: "1px solid #dee2e6", color: "#555", padding: "0.45rem 0.8rem", borderRadius: 4, cursor: "pointer", fontSize: "0.8rem" }}
+              >
+                Columns ({columns.length}/{allColumns.length}) {columnsMenuOpen ? "▲" : "▼"}
+              </button>
+              {columnsMenuOpen && (
+                <div style={{ position: "absolute", top: "calc(100% + 4px)", left: 0, zIndex: 50, background: "white", border: "1px solid #dee2e6", borderRadius: 6, boxShadow: "0 4px 12px rgba(0,0,0,0.12)", padding: "0.5rem", width: 300, maxHeight: 340, overflowY: "auto" }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "0.25rem 0.25rem 0.5rem", borderBottom: "1px solid #eee", marginBottom: 4 }}>
+                    <strong style={{ fontSize: "0.8rem", color: "#333" }}>Show columns</strong>
+                    <button onClick={resetColumns} style={{ background: "none", border: "none", color: "#007bff", cursor: "pointer", fontSize: "0.75rem" }}>
+                      Reset
+                    </button>
+                  </div>
+                  {allColumns.map((c) => (
+                    <label key={c} style={{ display: "flex", alignItems: "center", gap: 6, padding: "0.25rem", fontSize: "0.8rem", color: "#333", cursor: "pointer" }}>
+                      <input type="checkbox" checked={columns.includes(c)} onChange={() => toggleColumn(c)} />
+                      <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
           <span style={{ marginLeft: "auto", color: "#888", fontSize: "0.85rem" }}>
             {total.toLocaleString()} {query ? "matches" : "resources"}
             {sortField ? ` · sorted by ${sortField} (${sortOrder})` : ""}

--- a/src/LocalFileViewer.js
+++ b/src/LocalFileViewer.js
@@ -12,11 +12,10 @@ import * as sourcesApi from "./services/sourcesApi";
 
 const PAGE_SIZE = 25;
 const MAX_COLUMNS = 12; // keep the table readable; full detail is in drill-down
-// Above this size we don't ship the whole file to the backend (which caps at
-// 50 MB anyway). Instead we read only the first slice in the browser and upload
-// that as a preview, so a multi-GB NDJSON export loads instantly instead of
-// hanging on an endless upload.
-const PREVIEW_LIMIT_BYTES = 20 * 1024 * 1024; // 20 MB
+// Files above this size go to the streaming endpoint, which ingests them into a
+// disk-backed store instead of memory. That makes a multi-GB NDJSON export
+// fully browsable rather than truncated to a preview.
+const STREAM_THRESHOLD_BYTES = 20 * 1024 * 1024; // 20 MB
 
 const fmtSize = (bytes) => {
   if (bytes >= 1024 * 1024 * 1024) return (bytes / 1024 / 1024 / 1024).toFixed(1) + " GB";
@@ -34,7 +33,8 @@ function LocalFileViewer() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [selected, setSelected] = useState(null); // raw resource for drill-down
-  const [preview, setPreview] = useState(null); // { shownBytes, totalBytes } when a large file was truncated
+  const [preview, setPreview] = useState(null); // set when a large file was streamed to disk
+  const [streaming, setStreaming] = useState(null); // { totalBytes } while a large ingest runs
   const [query, setQuery] = useState(""); // applied text filter
   const [sortField, setSortField] = useState(null);
   const [sortOrder, setSortOrder] = useState("asc");
@@ -139,29 +139,25 @@ function LocalFileViewer() {
     (file) => {
       if (!file) return;
       setPreview(null);
+      setStreaming(null);
 
-      // Small files: upload as-is.
-      if (file.size <= PREVIEW_LIMIT_BYTES) {
+      // Small files: parse in memory, which is fastest for the common case.
+      if (file.size <= STREAM_THRESHOLD_BYTES) {
         adoptSource(() => sourcesApi.uploadSource(file));
         return;
       }
 
-      // Large files: read only the first slice in the browser and upload that,
-      // trimmed to the last complete line so the NDJSON stays valid.
+      // Large files: send the whole file to the streaming endpoint, which
+      // ingests it to disk so every resource stays browsable.
+      setStreaming({ totalBytes: file.size });
       adoptSource(async () => {
-        const slice = file.slice(0, PREVIEW_LIMIT_BYTES);
-        let text = await slice.text();
-        const lastNewline = text.lastIndexOf("\n");
-        if (lastNewline <= 0) {
-          throw new Error(
-            `File is ${fmtSize(file.size)} and can't be previewed by slicing. ` +
-              `Large-file preview supports newline-delimited JSON (NDJSON) exports.`
-          );
+        try {
+          const meta = await sourcesApi.uploadSourceStreaming(file);
+          setPreview({ streamed: true, totalBytes: file.size, total: meta.total });
+          return meta;
+        } finally {
+          setStreaming(null);
         }
-        text = text.slice(0, lastNewline);
-        const blob = new Blob([text], { type: "application/x-ndjson" });
-        setPreview({ shownBytes: blob.size, totalBytes: file.size });
-        return sourcesApi.uploadSource(blob, file.name);
       });
     },
     [adoptSource]
@@ -218,6 +214,7 @@ function LocalFileViewer() {
     setSelected(null);
     setError(null);
     setPreview(null);
+    setStreaming(null);
     setQuery("");
     setSortField(null);
     setSortOrder("asc");
@@ -386,9 +383,9 @@ function LocalFileViewer() {
             </button>
           </div>
           {preview && (
-            <div style={{ background: "#fff3cd", color: "#664d03", border: "1px solid #ffe69c", padding: "0.6rem 0.9rem", borderRadius: 4, marginBottom: "0.75rem", fontSize: "0.85rem" }}>
-              Large file: previewing the first {fmtSize(preview.shownBytes)} of {fmtSize(preview.totalBytes)}
-              {" "}({source.total.toLocaleString()} resources loaded). Split the export or filter it to load more.
+            <div style={{ background: "#d1e7dd", color: "#0a3622", border: "1px solid #a3cfbb", padding: "0.6rem 0.9rem", borderRadius: 4, marginBottom: "0.75rem", fontSize: "0.85rem" }}>
+              Streamed all {source.total.toLocaleString()} resources from {fmtSize(preview.totalBytes)} to a
+              disk-backed index. Search and sort run across the whole file.
             </div>
           )}
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
@@ -475,7 +472,13 @@ function LocalFileViewer() {
         </div>
       )}
 
-      {loading && <div style={{ color: "#666", padding: "1rem 0" }}>Loading…</div>}
+      {loading && (
+        <div style={{ color: "#666", padding: "1rem 0" }}>
+          {streaming
+            ? `Streaming ${fmtSize(streaming.totalBytes)} to a disk-backed index. Large files take a moment, and the whole file stays searchable.`
+            : "Loading…"}
+        </div>
+      )}
 
       {/* Table */}
       {!loading && source && activeType && rows.length > 0 && (

--- a/src/services/sourcesApi.js
+++ b/src/services/sourcesApi.js
@@ -45,6 +45,21 @@ export async function uploadSource(file, filename) {
 }
 
 /**
+ * Upload a large NDJSON file for streaming ingest. The backend writes it
+ * straight to a disk-backed store, so the whole file is browsable rather than
+ * only a preview of the start.
+ */
+export async function uploadSourceStreaming(file) {
+  const form = new FormData();
+  form.append('file', file);
+  const response = await fetch(`${SOURCES_BASE}/upload/stream`, {
+    method: 'POST',
+    body: form,
+  });
+  return handle(response);
+}
+
+/**
  * Load a FHIR object directly from S3 (s3://bucket/key).
  * `body` requires `uri`; region/endpoint_url/credentials are optional.
  * Returns the same source metadata shape as uploadSource.


### PR DESCRIPTION
Two features on top of the data-source viewer.

**Full multi-GB file support.** Replaces the previous large-file preview (first 20 MB only) with a streaming ingestion engine: NDJSON is read line by line into a SQLite index on disk instead of memory, so the entire export is browsable and peak memory stays flat. An FTS5 index built at ingest keeps search sub-second, and a per-column expression index is built the first time a column is sorted. Temp databases are removed on unload.

Measured on a 1.2 GB MIMIC export (1,107,278 resources): all resources browsable (was 18,151), search 7.1s to 0.5s, sort 7.4s to 0.23s, peak memory around 130 MB.

Note: for streamed files, search matches whole words and prefixes rather than arbitrary substrings, which is what keeps it fast at this scale. Smaller in-memory files keep exact substring matching.

**Column visibility.** A Columns dropdown to show or hide any column, with a reset to defaults, in both the readable and raw views.

75 automated tests for the data sources.
