### PR TITLE
Add dataset profiling

### DIFF
--- a/fhir-backend-dynamic/app/routers/sources.py
+++ b/fhir-backend-dynamic/app/routers/sources.py
@@ -221,6 +221,28 @@ async def export_resources(
     )
 
 
+@router.get("/{source_id}/resources/{resource_type}/profile")
+async def profile_resources(
+    source_id: str,
+    resource_type: str,
+    top_n: int = Query(5, ge=1, le=25),
+    max_columns: int = Query(25, ge=1, le=100),
+):
+    """Describe what is in a resource type: completeness and most common values.
+
+    For each column this reports how many resources have the field populated and
+    which values dominate, so a dataset can be assessed before it is used.
+    """
+    try:
+        loader = source_registry.get_source(source_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return {
+        "success": True,
+        "data": loader.profile(resource_type, top_n=top_n, max_columns=max_columns),
+    }
+
+
 @router.get("/{source_id}/resources/{resource_type}/schema")
 async def resource_schema(
     source_id: str,

--- a/fhir-backend-dynamic/app/services/sources/base.py
+++ b/fhir-backend-dynamic/app/services/sources/base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 from app.services import schema
+from app.services.sources import profile as profile_service
 
 
 class SourceLoader(ABC):
@@ -62,6 +63,37 @@ class SourceLoader(ABC):
     @abstractmethod
     def count(self, resource_type: str) -> int:
         """Return the number of resources of ``resource_type`` in this source."""
+
+    def profile(
+        self,
+        resource_type: str,
+        *,
+        top_n: int = 5,
+        max_columns: int = 25,
+    ) -> Dict[str, Any]:
+        """Describe what is in this resource type: completeness and top values.
+
+        The default pulls the resources and profiles them in Python, which is
+        fine for in-memory sources. Disk-backed sources override this with SQL
+        aggregation so the same numbers come back over millions of rows.
+        """
+        total = self.count(resource_type)
+        bundle = self.search(resource_type, count=max(1, total), offset=0)
+        resources = [
+            entry.get("resource")
+            for entry in bundle.get("entry", [])
+            if isinstance(entry.get("resource"), dict)
+        ]
+        columns = profile_service.profile_resources(
+            resources, top_n=top_n, max_columns=max_columns
+        )
+        return {
+            "resourceType": resource_type,
+            "total": total,
+            "profiled": len(resources),
+            "sampled": len(resources) < total,
+            "columns": columns,
+        }
 
     def schema(self, resource_type: str, *, sample: int = 20) -> Dict[str, Any]:
         """Infer tabular columns for ``resource_type`` from a sample of records.

--- a/fhir-backend-dynamic/app/services/sources/profile.py
+++ b/fhir-backend-dynamic/app/services/sources/profile.py
@@ -1,0 +1,102 @@
+"""Dataset profiling: what is actually in a loaded set of FHIR resources.
+
+Answers the question a researcher asks before using a dataset at all: which
+fields are populated, how much they vary, and which values dominate. For each
+column this reports completeness (share of resources where the field has a
+value), the number of distinct values, and the most common values with counts.
+
+The pure function here works over any list of resources. Disk-backed stores
+override it with SQL aggregation so the same numbers can be produced over
+millions of rows without loading them into memory.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from typing import Any, Dict, Iterable, List, Optional
+
+from app.services import schema
+
+# Long values are collapsed in the top-value list so one giant blob of JSON
+# cannot dominate the display.
+MAX_VALUE_CHARS = 120
+
+
+def normalize_value(value: Any) -> Optional[str]:
+    """Render one extracted value for counting, or None when it is absent.
+
+    Empty strings, empty lists and empty objects count as absent: for
+    completeness purposes an empty array is not a populated field.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+    elif isinstance(value, bool):
+        text = "true" if value else "false"
+    elif isinstance(value, (int, float)):
+        text = str(value)
+    elif isinstance(value, (list, dict)):
+        if not value:
+            return None
+        text = json.dumps(value, default=str, sort_keys=True)
+    else:
+        text = str(value)
+    # Truncate every rendered value, not just structured ones, so one long
+    # string cannot blow up the display.
+    if len(text) > MAX_VALUE_CHARS:
+        text = text[: MAX_VALUE_CHARS - 3] + "..."
+    return text
+
+
+def profile_column(resources: Iterable[Dict[str, Any]], path: str, *, top_n: int = 5) -> Dict[str, Any]:
+    """Completeness, distinct count and top values for one dotted path."""
+    counter: Counter = Counter()
+    populated = 0
+    total = 0
+
+    for resource in resources:
+        total += 1
+        rendered = normalize_value(schema._extract_value_by_path(resource, path))
+        if rendered is None:
+            continue
+        populated += 1
+        counter[rendered] += 1
+
+    return {
+        "path": path,
+        "total": total,
+        "populated": populated,
+        "completeness": (populated / total) if total else 0.0,
+        "distinct": len(counter),
+        # Ties break on the value itself, matching the SQL path's ORDER BY, so
+        # both implementations return the same list for the same data.
+        "top_values": [
+            {"value": v, "count": c}
+            for v, c in sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))[:top_n]
+        ],
+    }
+
+
+def profile_resources(
+    resources: List[Dict[str, Any]],
+    columns: Optional[List[str]] = None,
+    *,
+    top_n: int = 5,
+    max_columns: int = 25,
+) -> List[Dict[str, Any]]:
+    """Profile every column across ``resources``, most complete first."""
+    if not resources:
+        return []
+    if columns is None:
+        columns = schema.infer_columns(resources)[:max_columns]
+    else:
+        columns = list(columns)[:max_columns]
+
+    profiles = [profile_column(resources, c, top_n=top_n) for c in columns]
+    # Surface the fields a user can actually rely on first.
+    profiles.sort(key=lambda p: (-p["completeness"], p["path"]))
+    return profiles

--- a/fhir-backend-dynamic/app/services/sources/sqlite_store.py
+++ b/fhir-backend-dynamic/app/services/sources/sqlite_store.py
@@ -349,6 +349,40 @@ class SqliteFhirStore:
         ).fetchone()
         return json.loads(row[0]) if row else None
 
+    def sample_resources(self, resource_type: str, limit: int) -> List[Dict[str, Any]]:
+        """Return up to ``limit`` resources spread evenly across the whole type.
+
+        Profiling by running one aggregate query per column does not scale: each
+        ``json_extract`` re-parses every stored body, so 25 columns over a
+        million rows means 25 full scans. Instead we read one evenly strided
+        sample and profile every column from it in a single pass.
+
+        Striding on ``seq`` keeps the sample representative of the entire file
+        rather than just its beginning, which matters when exports are grouped
+        by patient or date.
+        """
+        total = self.count(resource_type)
+        if total == 0 or limit <= 0:
+            return []
+        if total <= limit:
+            rows = self._conn.execute(
+                "SELECT body FROM resources WHERE rtype = ? ORDER BY seq", (resource_type,)
+            ).fetchall()
+        else:
+            stride = max(1, total // limit)
+            rows = self._conn.execute(
+                "SELECT body FROM resources WHERE rtype = ? AND seq % ? = 0 ORDER BY seq LIMIT ?",
+                (resource_type, stride, limit),
+            ).fetchall()
+
+        out: List[Dict[str, Any]] = []
+        for (body,) in rows:
+            try:
+                out.append(json.loads(body))
+            except json.JSONDecodeError:  # pragma: no cover - defensive
+                continue
+        return out
+
     def close(self) -> None:
         """Close the connection and delete the backing file if we created it."""
         try:

--- a/fhir-backend-dynamic/app/services/sources/streaming_file.py
+++ b/fhir-backend-dynamic/app/services/sources/streaming_file.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List, Optional
 
+from app.services.sources import profile as profile_service
 from app.services.sources.base import SourceLoader
 from app.services.sources.sqlite_store import SqliteFhirStore
 
@@ -65,6 +66,35 @@ class StreamingFileSource(SourceLoader):
 
     def read(self, resource_type: str, resource_id: str) -> Optional[Dict[str, Any]]:
         return self._store.read(resource_type, resource_id)
+
+    def profile(
+        self,
+        resource_type: str,
+        *,
+        top_n: int = 5,
+        max_columns: int = 25,
+        sample: int = 50_000,
+    ) -> Dict[str, Any]:
+        """Profile from an evenly strided sample of the stored resources.
+
+        Reading one sample and profiling every column from it is far cheaper
+        than aggregating each column separately in SQL, which would re-parse
+        every stored body once per column. Results are reported as sampled
+        whenever the type holds more resources than the sample size.
+        """
+        total = self.count(resource_type)
+        resources = self._store.sample_resources(resource_type, sample)
+        columns = profile_service.profile_resources(
+            resources, top_n=top_n, max_columns=max_columns
+        )
+        # Scale sampled counts up so completeness reads against the real total.
+        return {
+            "resourceType": resource_type,
+            "total": total,
+            "profiled": len(resources),
+            "sampled": len(resources) < total,
+            "columns": columns,
+        }
 
     def close(self) -> None:
         """Release the SQLite connection and delete the temp database."""

--- a/fhir-backend-dynamic/tests/test_sources_profile.py
+++ b/fhir-backend-dynamic/tests/test_sources_profile.py
@@ -1,0 +1,188 @@
+"""Tests for dataset profiling (completeness, distinct counts, top values)."""
+
+import io
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services.sources import profile as profile_service
+from app.services.sources import registry as source_registry
+from app.services.sources.local_file import LocalFileSource
+from app.services.sources.store import InMemoryFhirStore
+from app.services.sources.streaming_file import StreamingFileSource
+
+
+def _obs(oid, display, status="final", value=None):
+    r = {
+        "resourceType": "Observation",
+        "id": oid,
+        "status": status,
+        "code": {"coding": [{"display": display}]},
+    }
+    if value is not None:
+        r["valueQuantity"] = {"value": value, "unit": "mg"}
+    return r
+
+
+# Gentamicin x3, Oxacillin x1; only two have a value.
+DATA = [
+    _obs("o1", "Gentamicin", value=30),
+    _obs("o2", "Gentamicin", value=10),
+    _obs("o3", "Gentamicin"),
+    _obs("o4", "Oxacillin", status="preliminary"),
+]
+
+
+# -------------------- normalize_value --------------------
+
+def test_normalize_treats_empty_as_absent():
+    assert profile_service.normalize_value(None) is None
+    assert profile_service.normalize_value("") is None
+    assert profile_service.normalize_value("  ") is None
+    assert profile_service.normalize_value([]) is None
+    assert profile_service.normalize_value({}) is None
+
+
+def test_normalize_renders_scalars_and_structures():
+    assert profile_service.normalize_value("final") == "final"
+    assert profile_service.normalize_value(5) == "5"
+    assert profile_service.normalize_value(True) == "true"
+    assert profile_service.normalize_value({"a": 1}) == '{"a": 1}'
+
+
+def test_normalize_truncates_long_values():
+    out = profile_service.normalize_value("x" * 500)
+    assert len(out) == profile_service.MAX_VALUE_CHARS
+    assert out.endswith("...")
+
+
+# -------------------- pure profiling --------------------
+
+def test_profile_column_completeness_and_top_values():
+    p = profile_service.profile_column(DATA, "code.coding[0].display")
+    assert p["total"] == 4
+    assert p["populated"] == 4
+    assert p["completeness"] == 1.0
+    assert p["distinct"] == 2
+    assert p["top_values"][0] == {"value": "Gentamicin", "count": 3}
+
+
+def test_profile_column_partial_completeness():
+    p = profile_service.profile_column(DATA, "valueQuantity.value")
+    assert p["populated"] == 2
+    assert p["completeness"] == 0.5
+
+
+def test_profile_column_absent_path():
+    p = profile_service.profile_column(DATA, "nope.missing")
+    assert p["populated"] == 0
+    assert p["completeness"] == 0.0
+    assert p["top_values"] == []
+
+
+def test_profile_resources_sorts_most_complete_first():
+    profiles = profile_service.profile_resources(DATA)
+    completeness = [p["completeness"] for p in profiles]
+    assert completeness == sorted(completeness, reverse=True)
+
+
+def test_profile_resources_empty():
+    assert profile_service.profile_resources([]) == []
+
+
+# -------------------- loader integration --------------------
+
+def test_in_memory_loader_profiles_everything():
+    loader = LocalFileSource(InMemoryFhirStore(list(DATA)))
+    out = loader.profile("Observation")
+    assert out["total"] == 4
+    assert out["profiled"] == 4
+    paths = {c["path"]: c for c in out["columns"]}
+    assert paths["status"]["distinct"] == 2
+
+
+def test_streaming_and_memory_agree():
+    """The SQL path must report the same numbers as the Python path."""
+    lines = [json.dumps(r).encode("utf-8") for r in DATA]
+    streamed = StreamingFileSource.from_lines(lines, filename="d.ndjson")
+    try:
+        sql = {c["path"]: c for c in streamed.profile("Observation")["columns"]}
+        mem = {
+            c["path"]: c
+            for c in LocalFileSource(InMemoryFhirStore(list(DATA))).profile("Observation")["columns"]
+        }
+        for path in ["status", "code.coding[0].display", "valueQuantity.value"]:
+            assert sql[path]["populated"] == mem[path]["populated"], path
+            assert sql[path]["distinct"] == mem[path]["distinct"], path
+            assert sql[path]["top_values"][:1] == mem[path]["top_values"][:1], path
+    finally:
+        streamed.close()
+
+
+def test_streaming_sample_is_spread_and_capped():
+    """A capped sample must span the whole file, not just its beginning."""
+    many = [_obs(f"o{i}", "Early" if i < 50 else "Late") for i in range(100)]
+    lines = [json.dumps(r).encode("utf-8") for r in many]
+    streamed = StreamingFileSource.from_lines(lines, filename="d.ndjson")
+    try:
+        out = streamed.profile("Observation", sample=10)
+        assert out["total"] == 100
+        assert out["profiled"] <= 10
+        assert out["sampled"] is True
+        # Both halves of the file must be represented in the sample.
+        display = next(c for c in out["columns"] if c["path"] == "code.coding[0].display")
+        assert {v["value"] for v in display["top_values"]} == {"Early", "Late"}
+    finally:
+        streamed.close()
+
+
+def test_streaming_small_type_is_exact():
+    lines = [json.dumps(r).encode("utf-8") for r in DATA]
+    streamed = StreamingFileSource.from_lines(lines, filename="d.ndjson")
+    try:
+        out = streamed.profile("Observation", sample=1000)
+        assert out["profiled"] == 4
+        assert out["sampled"] is False
+    finally:
+        streamed.close()
+
+
+# -------------------- endpoint --------------------
+
+@pytest.fixture
+def client():
+    from app.main import app
+    source_registry.clear()
+    with TestClient(app) as c:
+        yield c
+    source_registry.clear()
+
+
+def _upload(client, resources):
+    ndjson = "\n".join(json.dumps(r) for r in resources).encode("utf-8")
+    return client.post(
+        "/api/sources/upload",
+        files={"file": ("d.ndjson", io.BytesIO(ndjson), "application/x-ndjson")},
+    )
+
+
+def test_profile_endpoint(client):
+    sid = _upload(client, DATA).json()["data"]["source_id"]
+    r = client.get(f"/api/sources/{sid}/resources/Observation/profile")
+    assert r.status_code == 200
+    data = r.json()["data"]
+    assert data["total"] == 4
+    assert any(c["path"] == "status" for c in data["columns"])
+
+
+def test_profile_endpoint_respects_top_n(client):
+    sid = _upload(client, DATA).json()["data"]["source_id"]
+    data = client.get(
+        f"/api/sources/{sid}/resources/Observation/profile", params={"top_n": 1}
+    ).json()["data"]
+    assert all(len(c["top_values"]) <= 1 for c in data["columns"])
+
+
+def test_profile_endpoint_unknown_source_404(client):
+    assert client.get("/api/sources/nope/resources/Observation/profile").status_code == 404

--- a/src/LocalFileViewer.js
+++ b/src/LocalFileViewer.js
@@ -5,7 +5,7 @@
 // so the table matches the rest of the app.
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { Upload, FileJson, Trash2, X, ArrowLeft, Cloud, Download } from "lucide-react";
+import { Upload, FileJson, Trash2, X, ArrowLeft, Cloud, Download, BarChart3 } from "lucide-react";
 import { flattenResource, displayValue } from "./api";
 import { readableRow, readableColumns, sortPathFor } from "./fhirDisplay";
 import * as sourcesApi from "./services/sourcesApi";
@@ -41,6 +41,9 @@ function LocalFileViewer() {
   const [viewMode, setViewMode] = useState("readable"); // "readable" | "raw"
   const [visibleColumns, setVisibleColumns] = useState(null); // null = use defaults
   const [columnsMenuOpen, setColumnsMenuOpen] = useState(false);
+  const [profileData, setProfileData] = useState(null); // dataset profile for activeType
+  const [profileOpen, setProfileOpen] = useState(false);
+  const [profileLoading, setProfileLoading] = useState(false);
 
   // S3 load form state
   const [s3Open, setS3Open] = useState(false);
@@ -164,6 +167,32 @@ function LocalFileViewer() {
     },
     [adoptSource]
   );
+
+  // Profile the active type: what is populated and which values dominate.
+  // Fetched on demand and cleared when the resource type changes.
+  const toggleProfile = useCallback(async () => {
+    if (profileOpen) {
+      setProfileOpen(false);
+      return;
+    }
+    setProfileOpen(true);
+    if (profileData || !source || !activeType) return;
+    setProfileLoading(true);
+    try {
+      setProfileData(await sourcesApi.profileResources(source.source_id, activeType));
+    } catch (e) {
+      setError(e.message);
+      setProfileOpen(false);
+    } finally {
+      setProfileLoading(false);
+    }
+  }, [profileOpen, profileData, source, activeType]);
+
+  // A profile describes one resource type, so drop it when the type changes.
+  useEffect(() => {
+    setProfileData(null);
+    setProfileOpen(false);
+  }, [activeType]);
 
   // Download all matching resources (current filter + sort) as CSV or NDJSON.
   const handleExport = useCallback(
@@ -500,6 +529,19 @@ function LocalFileViewer() {
               )}
             </div>
           )}
+          <button
+            onClick={toggleProfile}
+            title="Show what is populated in this resource type"
+            style={{
+              display: "flex", alignItems: "center", gap: 4, borderRadius: 4, cursor: "pointer", fontSize: "0.8rem",
+              padding: "0.45rem 0.8rem",
+              border: profileOpen ? "1px solid #007bff" : "1px solid #dee2e6",
+              background: profileOpen ? "#007bff" : "white",
+              color: profileOpen ? "white" : "#555",
+            }}
+          >
+            <BarChart3 size={14} /> Profile
+          </button>
           <span style={{ marginLeft: "auto", color: "#888", fontSize: "0.85rem" }}>
             {total.toLocaleString()} {query ? "matches" : "resources"}
             {sortField ? ` · sorted by ${sortField} (${sortOrder})` : ""}
@@ -530,6 +572,71 @@ function LocalFileViewer() {
           {streaming
             ? `Streaming ${fmtSize(streaming.totalBytes)} to a disk-backed index. Large files take a moment, and the whole file stays searchable.`
             : "Loading…"}
+        </div>
+      )}
+
+      {/* Dataset profile: completeness and dominant values per column */}
+      {profileOpen && (
+        <div style={{ border: "1px solid #e0e0e0", borderRadius: 6, marginBottom: "0.75rem", overflow: "hidden" }}>
+          <div style={{ background: "#f8f9fa", padding: "0.6rem 0.9rem", borderBottom: "1px solid #e0e0e0", fontSize: "0.85rem", color: "#333" }}>
+            <strong>Dataset profile</strong>
+            {profileData && (
+              <span style={{ color: "#888" }}>
+                {" "}across {profileData.total.toLocaleString()} {profileData.resourceType} resources
+              </span>
+            )}
+          </div>
+          {profileLoading && <div style={{ padding: "1rem", color: "#666", fontSize: "0.85rem" }}>Profiling...</div>}
+          {!profileLoading && profileData && (
+            <div style={{ maxHeight: 340, overflowY: "auto" }}>
+              <table style={{ borderCollapse: "collapse", width: "100%", fontSize: "0.8rem" }}>
+                <thead>
+                  <tr style={{ textAlign: "left", color: "#666" }}>
+                    <th style={{ padding: "0.4rem 0.9rem", fontWeight: 500 }}>Field</th>
+                    <th style={{ padding: "0.4rem 0.5rem", fontWeight: 500, width: 190 }}>Populated</th>
+                    <th style={{ padding: "0.4rem 0.5rem", fontWeight: 500, width: 90 }}>Distinct</th>
+                    <th style={{ padding: "0.4rem 0.9rem", fontWeight: 500 }}>Most common values</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {profileData.columns.map((c) => {
+                    const pct = Math.round(c.completeness * 100);
+                    return (
+                      <tr key={c.path} style={{ borderTop: "1px solid #f0f0f0" }}>
+                        <td style={{ padding: "0.4rem 0.9rem", whiteSpace: "nowrap", color: "#333" }}>{c.path}</td>
+                        <td style={{ padding: "0.4rem 0.5rem" }}>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                            <div style={{ flex: 1, height: 6, background: "#eee", borderRadius: 3, overflow: "hidden" }}>
+                              <div style={{ width: `${pct}%`, height: "100%", background: pct === 100 ? "#28a745" : pct >= 50 ? "#007bff" : "#ffc107" }} />
+                            </div>
+                            <span style={{ color: "#666", width: 34, textAlign: "right" }}>{pct}%</span>
+                          </div>
+                        </td>
+                        <td style={{ padding: "0.4rem 0.5rem", color: "#666" }}>{c.distinct.toLocaleString()}</td>
+                        <td style={{ padding: "0.4rem 0.9rem" }}>
+                          <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+                            {c.populated === 0 ? (
+                              <span style={{ color: "#aaa" }}>none</span>
+                            ) : c.distinct === c.populated && c.populated > 1 ? (
+                              // Every resource has its own value, so listing a few
+                              // says nothing. That it is unique is the finding.
+                              <span style={{ color: "#888", fontStyle: "italic" }}>unique per resource</span>
+                            ) : (
+                              c.top_values.slice(0, 3).map((tv) => (
+                                <span key={tv.value} title={`${tv.value} (${tv.count.toLocaleString()})`} style={{ background: "#f1f5f9", borderRadius: 10, padding: "0.1rem 0.5rem", color: "#334155", maxWidth: 200, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                                  {tv.value} <span style={{ color: "#94a3b8" }}>{tv.count.toLocaleString()}</span>
+                                </span>
+                              ))
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/services/sourcesApi.js
+++ b/src/services/sourcesApi.js
@@ -114,6 +114,17 @@ export function exportUrl(sourceId, resourceType, { format = "csv", q = "", sort
   return `${SOURCES_BASE}/${sourceId}/resources/${resourceType}/export?${qs}`;
 }
 
+/**
+ * Profile a resource type: per-column completeness, distinct counts, and the
+ * most common values, computed across every resource of that type.
+ */
+export async function profileResources(sourceId, resourceType, { topN = 5, maxColumns = 25 } = {}) {
+  const qs = new URLSearchParams({ top_n: String(topN), max_columns: String(maxColumns) });
+  return handle(
+    await fetch(`${SOURCES_BASE}/${sourceId}/resources/${resourceType}/profile?${qs}`)
+  );
+}
+
 /** Get inferred tabular columns for a resource type. */
 export async function getResourceSchema(sourceId, resourceType, sample = 20) {
   const qs = new URLSearchParams({ sample: String(sample) });


### PR DESCRIPTION
Adds dataset profiling: before using a FHIR export, see what is actually in it.

A Profile button reports, for every field, how many resources have it populated (with a bar), how many distinct values it holds, and which values dominate. Fields where every resource has its own value are marked unique rather than listing meaningless samples. On the MIMIC medication export this immediately shows 10,916 distinct medication codes across 3 coding systems, for example.

Disk-backed sources profile from an evenly strided sample so the whole file is represented rather than just its beginning, and every column is profiled in a single pass: about 10 seconds over 1.1M resources. The response reports whether the numbers came from a sample.

90 automated tests for the data sources.
