### PR TITLE
Add reference integrity analysis and graph navigation

### DIFF
--- a/fhir-backend-dynamic/app/routers/sources.py
+++ b/fhir-backend-dynamic/app/routers/sources.py
@@ -243,6 +243,24 @@ async def profile_resources(
     }
 
 
+@router.get("/{source_id}/resources/{resource_type}/links")
+async def analyze_links(
+    source_id: str,
+    resource_type: str,
+    sample: int = Query(20_000, ge=1, le=200_000),
+):
+    """Report where this resource type points and whether those links resolve.
+
+    Resolution is checked against the loaded dataset, so a dangling link means
+    the target is not present in this file.
+    """
+    try:
+        loader = source_registry.get_source(source_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return {"success": True, "data": loader.links(resource_type, sample=sample)}
+
+
 @router.get("/{source_id}/resources/{resource_type}/schema")
 async def resource_schema(
     source_id: str,

--- a/fhir-backend-dynamic/app/services/sources/base.py
+++ b/fhir-backend-dynamic/app/services/sources/base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 from app.services import schema
+from app.services.sources import links as links_service
 from app.services.sources import profile as profile_service
 
 
@@ -93,6 +94,38 @@ class SourceLoader(ABC):
             "profiled": len(resources),
             "sampled": len(resources) < total,
             "columns": columns,
+        }
+
+    def links(self, resource_type: str, *, sample: int = 20_000) -> Dict[str, Any]:
+        """Report where this resource type points, and whether those links resolve.
+
+        The default profiles the resources it can load; disk-backed sources
+        override the sampling so a multi-GB export does not have to be read into
+        memory. Resolution is checked against the loaded dataset only, so a
+        dangling link means "not in this file", not "invalid".
+        """
+        total = self.count(resource_type)
+        bundle = self.search(resource_type, count=max(1, min(total, sample)), offset=0)
+        resources = [
+            entry.get("resource")
+            for entry in bundle.get("entry", [])
+            if isinstance(entry.get("resource"), dict)
+        ]
+        return self._links_payload(resource_type, resources, total)
+
+    def _links_payload(
+        self, resource_type: str, resources: List[Dict[str, Any]], total: int
+    ) -> Dict[str, Any]:
+        """Shared shaping for link analysis, given the resources to inspect."""
+        analyzed = links_service.analyze_links(
+            resources, lambda rt, rid: self.read(rt, rid) is not None
+        )
+        return {
+            "resourceType": resource_type,
+            "total": total,
+            "analyzed": len(resources),
+            "sampled": len(resources) < total,
+            "links": analyzed,
         }
 
     def schema(self, resource_type: str, *, sample: int = 20) -> Dict[str, Any]:

--- a/fhir-backend-dynamic/app/services/sources/links.py
+++ b/fhir-backend-dynamic/app/services/sources/links.py
@@ -1,0 +1,141 @@
+"""Reference integrity: do the links in this dataset actually resolve?
+
+FHIR resources form a graph. An Observation points at a Patient, an Encounter
+points at both. A table flattens that away, so a broken export looks fine until
+an analysis silently loses rows to references that point at data the file does
+not contain.
+
+This walks resources, collects every ``Reference`` element with the path it was
+found at, and checks whether each target exists in the loaded dataset. The
+result says, per link, how much of it resolves and gives concrete examples of
+what is missing.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple
+
+# "Patient/123", "Observation/abc-1", optionally with a version suffix, and
+# absolute URLs whose tail still carries Type/id.
+_REF_RE = re.compile(r"(?:^|/)([A-Z][A-Za-z]+)/([A-Za-z0-9\-.]{1,64})(?:/_history/.+)?$")
+
+MAX_DANGLING_EXAMPLES = 5
+
+
+def parse_reference(ref: str) -> Optional[Tuple[str, str]]:
+    """Split a FHIR reference string into ``(resource_type, id)``.
+
+    Handles relative references, absolute URLs, and version-specific ones.
+    Returns None for contained (``#local``) or otherwise unusable references.
+    """
+    if not isinstance(ref, str):
+        return None
+    ref = ref.strip()
+    if not ref or ref.startswith("#"):
+        return None  # contained resource, resolved inside its parent
+    if ref.startswith("urn:"):
+        return None  # bundle-local uuid, not addressable by type/id
+    match = _REF_RE.search(ref)
+    if not match:
+        return None
+    return match.group(1), match.group(2)
+
+
+def find_references(node: Any, prefix: str = "", out: Optional[List[Tuple[str, str]]] = None,
+                    depth: int = 0) -> List[Tuple[str, str]]:
+    """Collect ``(path, reference_string)`` for every Reference in a resource.
+
+    Array indices are collapsed so ``performer[0]`` and ``performer[1]`` report
+    as one ``performer`` link rather than fragmenting the summary.
+    """
+    if out is None:
+        out = []
+    if depth > 8:
+        return out
+
+    if isinstance(node, dict):
+        ref = node.get("reference")
+        if isinstance(ref, str) and prefix:
+            out.append((prefix, ref))
+        for key, value in node.items():
+            if key == "reference":
+                continue
+            child = f"{prefix}.{key}" if prefix else key
+            find_references(value, child, out, depth + 1)
+    elif isinstance(node, list):
+        for item in node:
+            find_references(item, prefix, out, depth + 1)
+
+    return out
+
+
+def analyze_links(
+    resources: Iterable[Dict[str, Any]],
+    exists: Callable[[str, str], bool],
+    *,
+    max_dangling_examples: int = MAX_DANGLING_EXAMPLES,
+) -> List[Dict[str, Any]]:
+    """Summarize every link, with how much of it resolves inside the dataset.
+
+    ``exists(resource_type, resource_id)`` reports whether a target is present.
+    Each distinct target is checked once, so a million references to a handful
+    of patients cost only a handful of lookups.
+    """
+    # (path, target_type) -> {"count": n, "targets": {id, ...}}
+    groups: Dict[Tuple[str, str], Dict[str, Any]] = defaultdict(
+        lambda: {"count": 0, "targets": set()}
+    )
+    unparsed = 0
+
+    for resource in resources:
+        for path, ref in find_references(resource):
+            parsed = parse_reference(ref)
+            if parsed is None:
+                unparsed += 1
+                continue
+            target_type, target_id = parsed
+            group = groups[(path, target_type)]
+            group["count"] += 1
+            group["targets"].add(target_id)
+
+    # Cache lookups so the same target is never checked twice across groups.
+    seen: Dict[Tuple[str, str], bool] = {}
+
+    def resolves(rtype: str, rid: str) -> bool:
+        key = (rtype, rid)
+        if key not in seen:
+            seen[key] = bool(exists(rtype, rid))
+        return seen[key]
+
+    results: List[Dict[str, Any]] = []
+    for (path, target_type), group in groups.items():
+        targets: Set[str] = group["targets"]
+        resolved = {t for t in targets if resolves(target_type, t)}
+        dangling = sorted(targets - resolved)
+        results.append({
+            "path": path,
+            "target_type": target_type,
+            "references": group["count"],
+            "distinct_targets": len(targets),
+            "resolved_targets": len(resolved),
+            "dangling_targets": len(dangling),
+            "resolution": (len(resolved) / len(targets)) if targets else 0.0,
+            "dangling_examples": [f"{target_type}/{t}" for t in dangling[:max_dangling_examples]],
+        })
+
+    # Most-used links first, then the least healthy.
+    results.sort(key=lambda r: (-r["references"], r["resolution"], r["path"]))
+    if unparsed:
+        results.append({
+            "path": "(unparseable)",
+            "target_type": "",
+            "references": unparsed,
+            "distinct_targets": 0,
+            "resolved_targets": 0,
+            "dangling_targets": 0,
+            "resolution": 0.0,
+            "dangling_examples": [],
+        })
+    return results

--- a/fhir-backend-dynamic/app/services/sources/streaming_file.py
+++ b/fhir-backend-dynamic/app/services/sources/streaming_file.py
@@ -67,6 +67,14 @@ class StreamingFileSource(SourceLoader):
     def read(self, resource_type: str, resource_id: str) -> Optional[Dict[str, Any]]:
         return self._store.read(resource_type, resource_id)
 
+    def links(self, resource_type: str, *, sample: int = 20_000) -> Dict[str, Any]:
+        """Analyze links from a strided sample rather than the whole table."""
+        return self._links_payload(
+            resource_type,
+            self._store.sample_resources(resource_type, sample),
+            self.count(resource_type),
+        )
+
     def profile(
         self,
         resource_type: str,

--- a/fhir-backend-dynamic/tests/test_sources_links.py
+++ b/fhir-backend-dynamic/tests/test_sources_links.py
@@ -1,0 +1,166 @@
+"""Tests for reference integrity analysis."""
+
+import io
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services.sources import links as links_service
+from app.services.sources import registry as source_registry
+from app.services.sources.local_file import LocalFileSource
+from app.services.sources.store import InMemoryFhirStore
+from app.services.sources.streaming_file import StreamingFileSource
+
+
+# -------------------- parse_reference --------------------
+
+@pytest.mark.parametrize("ref,expected", [
+    ("Patient/123", ("Patient", "123")),
+    ("Observation/abc-1.2", ("Observation", "abc-1.2")),
+    ("http://example.org/fhir/Patient/p1", ("Patient", "p1")),
+    ("Patient/123/_history/2", ("Patient", "123")),
+])
+def test_parse_reference_valid(ref, expected):
+    assert links_service.parse_reference(ref) == expected
+
+
+@pytest.mark.parametrize("ref", ["", "   ", "#contained", "urn:uuid:1234", "nonsense", None, 42])
+def test_parse_reference_rejects(ref):
+    assert links_service.parse_reference(ref) is None
+
+
+# -------------------- find_references --------------------
+
+def test_find_references_nested_and_arrays():
+    resource = {
+        "resourceType": "Observation",
+        "subject": {"reference": "Patient/p1"},
+        "encounter": {"reference": "Encounter/e1"},
+        "performer": [{"reference": "Practitioner/pr1"}, {"reference": "Practitioner/pr2"}],
+        "code": {"text": "no refs here"},
+    }
+    found = links_service.find_references(resource)
+    paths = {p for p, _ in found}
+    assert paths == {"subject", "encounter", "performer"}
+    # Array entries collapse onto one path rather than fragmenting.
+    assert sum(1 for p, _ in found if p == "performer") == 2
+
+
+def test_find_references_empty():
+    assert links_service.find_references({"resourceType": "Patient", "id": "p1"}) == []
+
+
+# -------------------- analyze_links --------------------
+
+OBS = [
+    {"resourceType": "Observation", "id": "o1", "subject": {"reference": "Patient/p1"}},
+    {"resourceType": "Observation", "id": "o2", "subject": {"reference": "Patient/p1"}},
+    {"resourceType": "Observation", "id": "o3", "subject": {"reference": "Patient/missing"}},
+]
+
+
+def test_analyze_links_reports_resolution():
+    present = {("Patient", "p1")}
+    out = links_service.analyze_links(OBS, lambda rt, rid: (rt, rid) in present)
+    assert len(out) == 1
+    link = out[0]
+    assert link["path"] == "subject"
+    assert link["target_type"] == "Patient"
+    assert link["references"] == 3
+    assert link["distinct_targets"] == 2
+    assert link["resolved_targets"] == 1
+    assert link["dangling_targets"] == 1
+    assert link["dangling_examples"] == ["Patient/missing"]
+
+
+def test_analyze_links_checks_each_target_once():
+    """A million references to one patient must cost one lookup."""
+    calls = []
+
+    def exists(rt, rid):
+        calls.append((rt, rid))
+        return True
+
+    many = [dict(OBS[0]) for _ in range(500)]
+    links_service.analyze_links(many, exists)
+    assert len(calls) == 1
+
+
+def test_analyze_links_counts_unparseable():
+    resources = [{"resourceType": "Observation", "subject": {"reference": "urn:uuid:xyz"}}]
+    out = links_service.analyze_links(resources, lambda rt, rid: True)
+    assert out[-1]["path"] == "(unparseable)"
+    assert out[-1]["references"] == 1
+
+
+def test_analyze_links_no_references():
+    assert links_service.analyze_links([{"resourceType": "Patient", "id": "p"}], lambda *_: True) == []
+
+
+# -------------------- loader integration --------------------
+
+PATIENTS = [{"resourceType": "Patient", "id": "p1"}]
+
+
+def test_loader_links_resolve_against_loaded_data():
+    loader = LocalFileSource(InMemoryFhirStore(OBS + PATIENTS))
+    out = loader.links("Observation")
+    assert out["total"] == 3
+    assert out["sampled"] is False
+    link = out["links"][0]
+    assert link["resolved_targets"] == 1
+    assert link["dangling_targets"] == 1
+
+
+def test_loader_links_all_dangling_without_targets():
+    """Observations alone: every patient link points outside the dataset."""
+    loader = LocalFileSource(InMemoryFhirStore(list(OBS)))
+    link = loader.links("Observation")["links"][0]
+    assert link["resolved_targets"] == 0
+    assert link["resolution"] == 0.0
+
+
+def test_streaming_links_match_in_memory():
+    lines = [json.dumps(r).encode("utf-8") for r in OBS + PATIENTS]
+    streamed = StreamingFileSource.from_lines(lines, filename="d.ndjson")
+    try:
+        sql = streamed.links("Observation")["links"][0]
+        mem = LocalFileSource(InMemoryFhirStore(OBS + PATIENTS)).links("Observation")["links"][0]
+        assert sql["references"] == mem["references"]
+        assert sql["resolved_targets"] == mem["resolved_targets"]
+        assert sql["dangling_targets"] == mem["dangling_targets"]
+    finally:
+        streamed.close()
+
+
+# -------------------- endpoint --------------------
+
+@pytest.fixture
+def client():
+    from app.main import app
+    source_registry.clear()
+    with TestClient(app) as c:
+        yield c
+    source_registry.clear()
+
+
+def _upload(client, resources):
+    ndjson = "\n".join(json.dumps(r) for r in resources).encode("utf-8")
+    return client.post(
+        "/api/sources/upload",
+        files={"file": ("d.ndjson", io.BytesIO(ndjson), "application/x-ndjson")},
+    )
+
+
+def test_links_endpoint(client):
+    sid = _upload(client, OBS + PATIENTS).json()["data"]["source_id"]
+    r = client.get(f"/api/sources/{sid}/resources/Observation/links")
+    assert r.status_code == 200
+    data = r.json()["data"]
+    assert data["links"][0]["target_type"] == "Patient"
+    assert data["links"][0]["dangling_targets"] == 1
+
+
+def test_links_endpoint_unknown_source_404(client):
+    assert client.get("/api/sources/nope/resources/Observation/links").status_code == 404

--- a/src/LocalFileViewer.js
+++ b/src/LocalFileViewer.js
@@ -5,7 +5,7 @@
 // so the table matches the rest of the app.
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { Upload, FileJson, Trash2, X, ArrowLeft, Cloud, Download, BarChart3 } from "lucide-react";
+import { Upload, FileJson, Trash2, X, ArrowLeft, Cloud, Download, BarChart3, Link2 as LinkIcon } from "lucide-react";
 import { flattenResource, displayValue } from "./api";
 import { readableRow, readableColumns, sortPathFor } from "./fhirDisplay";
 import * as sourcesApi from "./services/sourcesApi";
@@ -44,6 +44,9 @@ function LocalFileViewer() {
   const [profileData, setProfileData] = useState(null); // dataset profile for activeType
   const [profileOpen, setProfileOpen] = useState(false);
   const [profileLoading, setProfileLoading] = useState(false);
+  const [linksData, setLinksData] = useState(null); // reference integrity for activeType
+  const [linksOpen, setLinksOpen] = useState(false);
+  const [linksLoading, setLinksLoading] = useState(false);
 
   // S3 load form state
   const [s3Open, setS3Open] = useState(false);
@@ -188,10 +191,47 @@ function LocalFileViewer() {
     }
   }, [profileOpen, profileData, source, activeType]);
 
-  // A profile describes one resource type, so drop it when the type changes.
+  // Where does this type point, and do those links resolve in this dataset?
+  const toggleLinks = useCallback(async () => {
+    if (linksOpen) {
+      setLinksOpen(false);
+      return;
+    }
+    setLinksOpen(true);
+    if (linksData || !source || !activeType) return;
+    setLinksLoading(true);
+    try {
+      setLinksData(await sourcesApi.analyzeLinks(source.source_id, activeType));
+    } catch (e) {
+      setError(e.message);
+      setLinksOpen(false);
+    } finally {
+      setLinksLoading(false);
+    }
+  }, [linksOpen, linksData, source, activeType]);
+
+  // Jump from a reference in the drill-down to the resource it points at.
+  const followReference = useCallback(
+    async (ref) => {
+      if (!source) return;
+      const [targetType, targetId] = String(ref).split("/").slice(-2);
+      if (!targetType || !targetId) return;
+      try {
+        const target = await sourcesApi.readResource(source.source_id, targetType, targetId);
+        setSelected(target);
+      } catch {
+        setError(`${ref} is not present in this dataset.`);
+      }
+    },
+    [source]
+  );
+
+  // A profile and link map describe one resource type, so drop them on change.
   useEffect(() => {
     setProfileData(null);
     setProfileOpen(false);
+    setLinksData(null);
+    setLinksOpen(false);
   }, [activeType]);
 
   // Download all matching resources (current filter + sort) as CSV or NDJSON.
@@ -297,6 +337,38 @@ function LocalFileViewer() {
   );
 
   const resetColumns = useCallback(() => setVisibleColumns(null), []);
+
+  // References inside the open resource, so the drill-down can walk the graph.
+  const selectedRefs = useMemo(() => {
+    const found = [];
+    const walk = (node, path, depth) => {
+      if (!node || typeof node !== "object" || depth > 8) return;
+      if (Array.isArray(node)) {
+        node.forEach((item) => walk(item, path, depth + 1));
+        return;
+      }
+      if (typeof node.reference === "string" && path) {
+        const ref = node.reference.trim();
+        // Contained and bundle-local references are not addressable by id.
+        if (ref && !ref.startsWith("#") && !ref.startsWith("urn:")) {
+          found.push({ path, ref });
+        }
+      }
+      Object.entries(node).forEach(([key, value]) => {
+        if (key === "reference") return;
+        walk(value, path ? `${path}.${key}` : key, depth + 1);
+      });
+    };
+    walk(selected, "", 0);
+    // De-duplicate repeated targets so the strip stays short.
+    const seen = new Set();
+    return found.filter(({ path, ref }) => {
+      const key = `${path}:${ref}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }, [selected]);
 
   const page = Math.floor(offset / PAGE_SIZE) + 1;
   const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -542,6 +614,19 @@ function LocalFileViewer() {
           >
             <BarChart3 size={14} /> Profile
           </button>
+          <button
+            onClick={toggleLinks}
+            title="Check whether this type's references resolve inside the dataset"
+            style={{
+              display: "flex", alignItems: "center", gap: 4, borderRadius: 4, cursor: "pointer", fontSize: "0.8rem",
+              padding: "0.45rem 0.8rem",
+              border: linksOpen ? "1px solid #007bff" : "1px solid #dee2e6",
+              background: linksOpen ? "#007bff" : "white",
+              color: linksOpen ? "white" : "#555",
+            }}
+          >
+            <LinkIcon size={14} /> Links
+          </button>
           <span style={{ marginLeft: "auto", color: "#888", fontSize: "0.85rem" }}>
             {total.toLocaleString()} {query ? "matches" : "resources"}
             {sortField ? ` · sorted by ${sortField} (${sortOrder})` : ""}
@@ -636,6 +721,66 @@ function LocalFileViewer() {
                 </tbody>
               </table>
             </div>
+          )}
+        </div>
+      )}
+
+      {/* Reference integrity: where this type points, and what resolves */}
+      {linksOpen && (
+        <div style={{ border: "1px solid #e0e0e0", borderRadius: 6, marginBottom: "0.75rem", overflow: "hidden" }}>
+          <div style={{ background: "#f8f9fa", padding: "0.6rem 0.9rem", borderBottom: "1px solid #e0e0e0", fontSize: "0.85rem", color: "#333" }}>
+            <strong>References</strong>
+            {linksData && (
+              <span style={{ color: "#888" }}>
+                {" "}from {linksData.analyzed.toLocaleString()} {linksData.resourceType} resources
+                {linksData.sampled ? " (sampled)" : ""}
+              </span>
+            )}
+          </div>
+          {linksLoading && <div style={{ padding: "1rem", color: "#666", fontSize: "0.85rem" }}>Checking references...</div>}
+          {!linksLoading && linksData && linksData.links.length === 0 && (
+            <div style={{ padding: "1rem", color: "#666", fontSize: "0.85rem" }}>
+              This resource type has no references to other resources.
+            </div>
+          )}
+          {!linksLoading && linksData && linksData.links.length > 0 && (
+            <table style={{ borderCollapse: "collapse", width: "100%", fontSize: "0.8rem" }}>
+              <thead>
+                <tr style={{ textAlign: "left", color: "#666" }}>
+                  <th style={{ padding: "0.4rem 0.9rem", fontWeight: 500 }}>Link</th>
+                  <th style={{ padding: "0.4rem 0.5rem", fontWeight: 500 }}>References</th>
+                  <th style={{ padding: "0.4rem 0.5rem", fontWeight: 500 }}>Targets</th>
+                  <th style={{ padding: "0.4rem 0.5rem", fontWeight: 500, width: 200 }}>Found in dataset</th>
+                  <th style={{ padding: "0.4rem 0.9rem", fontWeight: 500 }}>Missing examples</th>
+                </tr>
+              </thead>
+              <tbody>
+                {linksData.links.map((l) => {
+                  const pct = Math.round(l.resolution * 100);
+                  return (
+                    <tr key={`${l.path}->${l.target_type}`} style={{ borderTop: "1px solid #f0f0f0" }}>
+                      <td style={{ padding: "0.4rem 0.9rem", whiteSpace: "nowrap", color: "#333" }}>
+                        {l.path} <span style={{ color: "#94a3b8" }}>to</span>{" "}
+                        <strong style={{ color: "#334155" }}>{l.target_type}</strong>
+                      </td>
+                      <td style={{ padding: "0.4rem 0.5rem", color: "#666" }}>{l.references.toLocaleString()}</td>
+                      <td style={{ padding: "0.4rem 0.5rem", color: "#666" }}>{l.distinct_targets.toLocaleString()}</td>
+                      <td style={{ padding: "0.4rem 0.5rem" }}>
+                        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                          <div style={{ flex: 1, height: 6, background: "#eee", borderRadius: 3, overflow: "hidden" }}>
+                            <div style={{ width: `${pct}%`, height: "100%", background: pct === 100 ? "#28a745" : pct > 0 ? "#ffc107" : "#dc3545" }} />
+                          </div>
+                          <span style={{ color: "#666", width: 34, textAlign: "right" }}>{pct}%</span>
+                        </div>
+                      </td>
+                      <td style={{ padding: "0.4rem 0.9rem", color: "#94a3b8", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 260 }}>
+                        {l.dangling_examples.length ? l.dangling_examples.join(", ") : "none"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
           )}
         </div>
       )}
@@ -743,6 +888,26 @@ function LocalFileViewer() {
                 <X size={20} color="#666" />
               </button>
             </div>
+            {selectedRefs.length > 0 && (
+              <div style={{ marginBottom: "0.75rem" }}>
+                <div style={{ fontSize: "0.75rem", color: "#888", marginBottom: 4 }}>
+                  Referenced resources (click to follow)
+                </div>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                  {selectedRefs.map(({ path, ref }) => (
+                    <button
+                      key={`${path}:${ref}`}
+                      onClick={() => followReference(ref)}
+                      title={`Open ${ref}`}
+                      style={{ display: "flex", alignItems: "center", gap: 4, background: "#eff6ff", border: "1px solid #bfdbfe", color: "#1d4ed8", borderRadius: 12, padding: "0.2rem 0.6rem", cursor: "pointer", fontSize: "0.75rem" }}
+                    >
+                      <LinkIcon size={12} />
+                      <span style={{ color: "#64748b" }}>{path}:</span> {ref}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
             <pre
               style={{
                 background: "#0d1117", color: "#c9d1d9", padding: "1rem", borderRadius: 6,

--- a/src/services/sourcesApi.js
+++ b/src/services/sourcesApi.js
@@ -125,6 +125,17 @@ export async function profileResources(sourceId, resourceType, { topN = 5, maxCo
   );
 }
 
+/**
+ * Analyze where a resource type points and whether those links resolve inside
+ * the loaded dataset.
+ */
+export async function analyzeLinks(sourceId, resourceType, { sample = 20000 } = {}) {
+  const qs = new URLSearchParams({ sample: String(sample) });
+  return handle(
+    await fetch(`${SOURCES_BASE}/${sourceId}/resources/${resourceType}/links?${qs}`)
+  );
+}
+
 /** Get inferred tabular columns for a resource type. */
 export async function getResourceSchema(sourceId, resourceType, sample = 20) {
   const qs = new URLSearchParams({ sample: String(sample) });


### PR DESCRIPTION
FHIR resources form a graph, but a table flattens that away. A broken export then looks fine until an analysis silently loses rows to references pointing at data the file does not contain.

A Links button now reports, per reference path, how many distinct targets it has and what share of them exist inside the loaded dataset, with examples of what is missing. Colour makes the state obvious: green when everything resolves, amber when partly, red when the target type is absent entirely.

The drill-down also lists a resource's references as buttons that open the resource they point at, so the graph stays walkable from a flat table.

On a real MIMIC observation export this immediately shows that all 134 referenced patients and 297 parent observations are absent from the file.

Each distinct target is checked once, so a million references to a few patients cost a few lookups. Disk-backed sources analyze a strided sample.

112 automated tests for the data sources.
