### PR TITLE
Add terminology coverage analysis

### DIFF
--- a/fhir-backend-dynamic/app/routers/sources.py
+++ b/fhir-backend-dynamic/app/routers/sources.py
@@ -243,6 +243,25 @@ async def profile_resources(
     }
 
 
+@router.get("/{source_id}/resources/{resource_type}/terminology")
+async def analyze_terminology(
+    source_id: str,
+    resource_type: str,
+    sample: int = Query(20_000, ge=1, le=200_000),
+):
+    """Report which code systems this resource type uses.
+
+    Distinguishes recognized standards from local systems, and counts concepts
+    that carry only free text or no system, since those cannot be pooled with
+    data coded elsewhere.
+    """
+    try:
+        loader = source_registry.get_source(source_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return {"success": True, "data": loader.terminology(resource_type, sample=sample)}
+
+
 @router.get("/{source_id}/resources/{resource_type}/links")
 async def analyze_links(
     source_id: str,

--- a/fhir-backend-dynamic/app/services/sources/base.py
+++ b/fhir-backend-dynamic/app/services/sources/base.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 from app.services import schema
 from app.services.sources import links as links_service
 from app.services.sources import profile as profile_service
+from app.services.sources import terminology as terminology_service
 
 
 class SourceLoader(ABC):
@@ -95,6 +96,34 @@ class SourceLoader(ABC):
             "sampled": len(resources) < total,
             "columns": columns,
         }
+
+    def terminology(self, resource_type: str, *, sample: int = 20_000) -> Dict[str, Any]:
+        """Report which code systems this resource type uses.
+
+        Says how much of the coded data sits in recognized standards versus
+        local systems, which is what determines whether it can be pooled with
+        data from elsewhere.
+        """
+        total = self.count(resource_type)
+        resources = self._sample(resource_type, sample)
+        payload = terminology_service.analyze_terminology(resources)
+        payload.update({
+            "resourceType": resource_type,
+            "total": total,
+            "analyzed": len(resources),
+            "sampled": len(resources) < total,
+        })
+        return payload
+
+    def _sample(self, resource_type: str, limit: int) -> List[Dict[str, Any]]:
+        """Return up to ``limit`` resources. Disk-backed sources stride instead."""
+        total = self.count(resource_type)
+        bundle = self.search(resource_type, count=max(1, min(total, limit)), offset=0)
+        return [
+            entry.get("resource")
+            for entry in bundle.get("entry", [])
+            if isinstance(entry.get("resource"), dict)
+        ]
 
     def links(self, resource_type: str, *, sample: int = 20_000) -> Dict[str, Any]:
         """Report where this resource type points, and whether those links resolve.

--- a/fhir-backend-dynamic/app/services/sources/streaming_file.py
+++ b/fhir-backend-dynamic/app/services/sources/streaming_file.py
@@ -67,6 +67,10 @@ class StreamingFileSource(SourceLoader):
     def read(self, resource_type: str, resource_id: str) -> Optional[Dict[str, Any]]:
         return self._store.read(resource_type, resource_id)
 
+    def _sample(self, resource_type: str, limit: int) -> List[Dict[str, Any]]:
+        """Stride across the whole table instead of reading it into memory."""
+        return self._store.sample_resources(resource_type, limit)
+
     def links(self, resource_type: str, *, sample: int = 20_000) -> Dict[str, Any]:
         """Analyze links from a strided sample rather than the whole table."""
         return self._links_payload(

--- a/fhir-backend-dynamic/app/services/sources/terminology.py
+++ b/fhir-backend-dynamic/app/services/sources/terminology.py
@@ -1,0 +1,156 @@
+"""Terminology coverage: is this data coded in standards anyone else can read?
+
+FHIR's value is standardized terminology. A dataset coded in LOINC and SNOMED
+can be pooled across institutions; the same data in local codes cannot, and the
+difference is invisible in a table of values. This walks the codings in a
+resource type and reports which code systems are in use, how many are
+recognized standards, and where coding is missing entirely.
+
+Three problems are called out specifically, because each one blocks reuse:
+  * codes from local or proprietary systems,
+  * codes with no ``system`` at all, so they cannot be resolved, and
+  * concepts carrying only free text, with no code.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+# Recognized systems, matched by prefix so versioned and regional variants
+# (for example ICD-10-CM) still resolve to their family.
+KNOWN_SYSTEMS: List[Tuple[str, str]] = [
+    ("http://loinc.org", "LOINC"),
+    ("http://snomed.info/sct", "SNOMED CT"),
+    ("http://www.nlm.nih.gov/research/umls/rxnorm", "RxNorm"),
+    ("http://hl7.org/fhir/sid/icd-10", "ICD-10"),
+    ("http://hl7.org/fhir/sid/icd-9", "ICD-9"),
+    ("http://hl7.org/fhir/sid/ndc", "NDC"),
+    ("http://hl7.org/fhir/sid/cvx", "CVX"),
+    ("http://unitsofmeasure.org", "UCUM"),
+    ("http://www.ama-assn.org/go/cpt", "CPT"),
+    ("http://terminology.hl7.org", "HL7 terminology"),
+    ("http://hl7.org/fhir", "FHIR core"),
+    ("urn:iso:std:iso:3166", "ISO 3166"),
+]
+
+MAX_EXAMPLES = 3
+
+
+def classify_system(system: Optional[str]) -> Tuple[str, bool]:
+    """Return ``(display_name, is_recognized)`` for a code system URI."""
+    if not system or not str(system).strip():
+        return ("(no system)", False)
+    system = str(system).strip()
+    for prefix, name in KNOWN_SYSTEMS:
+        if system.startswith(prefix):
+            return (name, True)
+    return (system, False)
+
+
+def find_codings(node: Any, prefix: str = "", out: Optional[List[Dict[str, Any]]] = None,
+                 depth: int = 0) -> List[Dict[str, Any]]:
+    """Collect every coded concept, with the path it was found at.
+
+    Yields one entry per ``Coding`` inside a ``CodeableConcept``, plus a
+    ``text_only`` marker for concepts that carry text but no coding at all.
+    """
+    if out is None:
+        out = []
+    if depth > 8 or node is None:
+        return out
+
+    if isinstance(node, list):
+        for item in node:
+            find_codings(item, prefix, out, depth + 1)
+        return out
+
+    if not isinstance(node, dict):
+        return out
+
+    codings = node.get("coding")
+    if isinstance(codings, list) and codings:
+        for coding in codings:
+            if isinstance(coding, dict):
+                out.append({
+                    "path": prefix,
+                    "system": coding.get("system"),
+                    "code": coding.get("code"),
+                    "display": coding.get("display") or node.get("text"),
+                    "text_only": False,
+                })
+    elif isinstance(node.get("text"), str) and node.get("text").strip() and prefix:
+        # A CodeableConcept with text but nothing coded: human readable, but
+        # not machine comparable across systems.
+        out.append({
+            "path": prefix, "system": None, "code": None,
+            "display": node["text"], "text_only": True,
+        })
+
+    for key, value in node.items():
+        if key in ("coding", "text"):
+            continue
+        child = f"{prefix}.{key}" if prefix else key
+        find_codings(value, child, out, depth + 1)
+
+    return out
+
+
+def analyze_terminology(resources: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    """Summarize code system usage across resources."""
+    systems: Dict[str, Dict[str, Any]] = defaultdict(
+        lambda: {"codes": set(), "count": 0, "paths": set(), "examples": []}
+    )
+    total_codings = 0
+    text_only = 0
+    missing_system = 0
+
+    for resource in resources:
+        for hit in find_codings(resource):
+            if hit["text_only"]:
+                text_only += 1
+                continue
+            total_codings += 1
+            name, recognized = classify_system(hit["system"])
+            entry = systems[name]
+            entry["count"] += 1
+            entry["recognized"] = recognized
+            entry["uri"] = hit["system"]
+            entry["paths"].add(hit["path"])
+            if hit["code"]:
+                entry["codes"].add(str(hit["code"]))
+            if not hit["system"]:
+                missing_system += 1
+            if len(entry["examples"]) < MAX_EXAMPLES and hit["code"]:
+                label = f"{hit['code']}"
+                if hit["display"]:
+                    label += f" ({hit['display']})"
+                if label not in entry["examples"]:
+                    entry["examples"].append(label)
+
+    rows = [
+        {
+            "system": name,
+            "uri": entry.get("uri"),
+            "recognized": bool(entry.get("recognized")),
+            "codings": entry["count"],
+            "distinct_codes": len(entry["codes"]),
+            "paths": sorted(entry["paths"]),
+            "examples": entry["examples"],
+            "share": (entry["count"] / total_codings) if total_codings else 0.0,
+        }
+        for name, entry in systems.items()
+    ]
+    # Standards first, then by how much of the data they carry.
+    rows.sort(key=lambda r: (not r["recognized"], -r["codings"], r["system"]))
+
+    standard = sum(r["codings"] for r in rows if r["recognized"])
+    return {
+        "total_codings": total_codings,
+        "standard_codings": standard,
+        "local_codings": total_codings - standard,
+        "standard_share": (standard / total_codings) if total_codings else 0.0,
+        "text_only_concepts": text_only,
+        "codings_without_system": missing_system,
+        "systems": rows,
+    }

--- a/fhir-backend-dynamic/tests/test_sources_terminology.py
+++ b/fhir-backend-dynamic/tests/test_sources_terminology.py
@@ -1,0 +1,166 @@
+"""Tests for terminology coverage analysis."""
+
+import io
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services.sources import registry as source_registry
+from app.services.sources import terminology as term
+from app.services.sources.local_file import LocalFileSource
+from app.services.sources.store import InMemoryFhirStore
+from app.services.sources.streaming_file import StreamingFileSource
+
+
+# -------------------- classify_system --------------------
+
+@pytest.mark.parametrize("uri,name", [
+    ("http://loinc.org", "LOINC"),
+    ("http://snomed.info/sct", "SNOMED CT"),
+    ("http://hl7.org/fhir/sid/icd-10-cm", "ICD-10"),
+    ("http://unitsofmeasure.org", "UCUM"),
+    ("http://terminology.hl7.org/CodeSystem/observation-category", "HL7 terminology"),
+])
+def test_classify_known_systems(uri, name):
+    display, recognized = term.classify_system(uri)
+    assert (display, recognized) == (name, True)
+
+
+def test_classify_local_system_is_not_recognized():
+    display, recognized = term.classify_system("http://mimic.mit.edu/fhir/mimic/CodeSystem/x")
+    assert recognized is False
+    assert display == "http://mimic.mit.edu/fhir/mimic/CodeSystem/x"
+
+
+@pytest.mark.parametrize("uri", [None, "", "   "])
+def test_classify_missing_system(uri):
+    assert term.classify_system(uri) == ("(no system)", False)
+
+
+# -------------------- find_codings --------------------
+
+def test_find_codings_records_path_and_values():
+    resource = {
+        "resourceType": "Observation",
+        "code": {"coding": [{"system": "http://loinc.org", "code": "8867-4", "display": "Heart rate"}]},
+        "category": [{"coding": [{"system": "http://terminology.hl7.org/CodeSystem/x", "code": "vital-signs"}]}],
+    }
+    hits = term.find_codings(resource)
+    paths = {h["path"] for h in hits}
+    assert paths == {"code", "category"}
+    assert any(h["code"] == "8867-4" for h in hits)
+
+
+def test_find_codings_flags_text_only_concepts():
+    hits = term.find_codings({"resourceType": "Condition", "code": {"text": "chest pain"}})
+    assert len(hits) == 1
+    assert hits[0]["text_only"] is True
+
+
+def test_find_codings_ignores_uncoded_resources():
+    assert term.find_codings({"resourceType": "Patient", "id": "p1", "gender": "male"}) == []
+
+
+# -------------------- analyze_terminology --------------------
+
+MIXED = [
+    {"resourceType": "Observation",
+     "code": {"coding": [{"system": "http://loinc.org", "code": "8867-4", "display": "Heart rate"}]}},
+    {"resourceType": "Observation",
+     "code": {"coding": [{"system": "http://loinc.org", "code": "2339-0", "display": "Glucose"}]}},
+    {"resourceType": "Observation",
+     "code": {"coding": [{"system": "http://local.example/codes", "code": "LOC-1"}]}},
+    {"resourceType": "Observation", "code": {"text": "free text only"}},
+    {"resourceType": "Observation", "code": {"coding": [{"code": "NOSYS"}]}},
+]
+
+
+def test_analyze_splits_standard_from_local():
+    out = term.analyze_terminology(MIXED)
+    assert out["total_codings"] == 4  # text-only is not a coding
+    assert out["standard_codings"] == 2  # the two LOINC ones
+    assert out["local_codings"] == 2  # local system + missing system
+    assert out["standard_share"] == 0.5
+
+
+def test_analyze_counts_text_only_and_missing_system():
+    out = term.analyze_terminology(MIXED)
+    assert out["text_only_concepts"] == 1
+    assert out["codings_without_system"] == 1
+
+
+def test_analyze_lists_standards_first():
+    systems = term.analyze_terminology(MIXED)["systems"]
+    assert systems[0]["system"] == "LOINC"
+    assert systems[0]["recognized"] is True
+    assert systems[0]["distinct_codes"] == 2
+    assert all(not s["recognized"] for s in systems[1:])
+
+
+def test_analyze_reports_examples_and_paths():
+    loinc = term.analyze_terminology(MIXED)["systems"][0]
+    assert loinc["paths"] == ["code"]
+    assert any("Heart rate" in e for e in loinc["examples"])
+
+
+def test_analyze_empty():
+    out = term.analyze_terminology([])
+    assert out["total_codings"] == 0
+    assert out["standard_share"] == 0.0
+    assert out["systems"] == []
+
+
+# -------------------- loader integration --------------------
+
+def test_loader_terminology():
+    loader = LocalFileSource(InMemoryFhirStore(list(MIXED)))
+    out = loader.terminology("Observation")
+    assert out["resourceType"] == "Observation"
+    assert out["total"] == 5
+    assert out["sampled"] is False
+    assert out["standard_codings"] == 2
+
+
+def test_streaming_and_memory_agree():
+    lines = [json.dumps(r).encode("utf-8") for r in MIXED]
+    streamed = StreamingFileSource.from_lines(lines, filename="d.ndjson")
+    try:
+        sql = streamed.terminology("Observation")
+        mem = LocalFileSource(InMemoryFhirStore(list(MIXED))).terminology("Observation")
+        for key in ["total_codings", "standard_codings", "local_codings", "text_only_concepts"]:
+            assert sql[key] == mem[key], key
+    finally:
+        streamed.close()
+
+
+# -------------------- endpoint --------------------
+
+@pytest.fixture
+def client():
+    from app.main import app
+    source_registry.clear()
+    with TestClient(app) as c:
+        yield c
+    source_registry.clear()
+
+
+def _upload(client, resources):
+    ndjson = "\n".join(json.dumps(r) for r in resources).encode("utf-8")
+    return client.post(
+        "/api/sources/upload",
+        files={"file": ("d.ndjson", io.BytesIO(ndjson), "application/x-ndjson")},
+    )
+
+
+def test_terminology_endpoint(client):
+    sid = _upload(client, MIXED).json()["data"]["source_id"]
+    r = client.get(f"/api/sources/{sid}/resources/Observation/terminology")
+    assert r.status_code == 200
+    data = r.json()["data"]
+    assert data["standard_codings"] == 2
+    assert data["systems"][0]["system"] == "LOINC"
+
+
+def test_terminology_endpoint_unknown_source_404(client):
+    assert client.get("/api/sources/x/resources/Observation/terminology").status_code == 404

--- a/src/LocalFileViewer.js
+++ b/src/LocalFileViewer.js
@@ -5,7 +5,7 @@
 // so the table matches the rest of the app.
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { Upload, FileJson, Trash2, X, ArrowLeft, Cloud, Download, BarChart3, Link2 as LinkIcon } from "lucide-react";
+import { Upload, FileJson, Trash2, X, ArrowLeft, Cloud, Download, BarChart3, Link2 as LinkIcon, Tags } from "lucide-react";
 import { flattenResource, displayValue } from "./api";
 import { readableRow, readableColumns, sortPathFor } from "./fhirDisplay";
 import * as sourcesApi from "./services/sourcesApi";
@@ -47,6 +47,9 @@ function LocalFileViewer() {
   const [linksData, setLinksData] = useState(null); // reference integrity for activeType
   const [linksOpen, setLinksOpen] = useState(false);
   const [linksLoading, setLinksLoading] = useState(false);
+  const [termData, setTermData] = useState(null); // code system coverage
+  const [termOpen, setTermOpen] = useState(false);
+  const [termLoading, setTermLoading] = useState(false);
 
   // S3 load form state
   const [s3Open, setS3Open] = useState(false);
@@ -210,6 +213,25 @@ function LocalFileViewer() {
     }
   }, [linksOpen, linksData, source, activeType]);
 
+  // Which code systems does this type use, and are they standards?
+  const toggleTerminology = useCallback(async () => {
+    if (termOpen) {
+      setTermOpen(false);
+      return;
+    }
+    setTermOpen(true);
+    if (termData || !source || !activeType) return;
+    setTermLoading(true);
+    try {
+      setTermData(await sourcesApi.analyzeTerminology(source.source_id, activeType));
+    } catch (e) {
+      setError(e.message);
+      setTermOpen(false);
+    } finally {
+      setTermLoading(false);
+    }
+  }, [termOpen, termData, source, activeType]);
+
   // Jump from a reference in the drill-down to the resource it points at.
   const followReference = useCallback(
     async (ref) => {
@@ -232,6 +254,8 @@ function LocalFileViewer() {
     setProfileOpen(false);
     setLinksData(null);
     setLinksOpen(false);
+    setTermData(null);
+    setTermOpen(false);
   }, [activeType]);
 
   // Download all matching resources (current filter + sort) as CSV or NDJSON.
@@ -627,6 +651,19 @@ function LocalFileViewer() {
           >
             <LinkIcon size={14} /> Links
           </button>
+          <button
+            onClick={toggleTerminology}
+            title="Which code systems this data uses, and whether they are standards"
+            style={{
+              display: "flex", alignItems: "center", gap: 4, borderRadius: 4, cursor: "pointer", fontSize: "0.8rem",
+              padding: "0.45rem 0.8rem",
+              border: termOpen ? "1px solid #007bff" : "1px solid #dee2e6",
+              background: termOpen ? "#007bff" : "white",
+              color: termOpen ? "white" : "#555",
+            }}
+          >
+            <Tags size={14} /> Codes
+          </button>
           <span style={{ marginLeft: "auto", color: "#888", fontSize: "0.85rem" }}>
             {total.toLocaleString()} {query ? "matches" : "resources"}
             {sortField ? ` · sorted by ${sortField} (${sortOrder})` : ""}
@@ -721,6 +758,81 @@ function LocalFileViewer() {
                 </tbody>
               </table>
             </div>
+          )}
+        </div>
+      )}
+
+      {/* Terminology: which code systems this data speaks */}
+      {termOpen && (
+        <div style={{ border: "1px solid #e0e0e0", borderRadius: 6, marginBottom: "0.75rem", overflow: "hidden" }}>
+          <div style={{ background: "#f8f9fa", padding: "0.6rem 0.9rem", borderBottom: "1px solid #e0e0e0", fontSize: "0.85rem", color: "#333" }}>
+            <strong>Code systems</strong>
+            {termData && (
+              <span style={{ color: "#888" }}>
+                {" "}from {termData.analyzed.toLocaleString()} {termData.resourceType} resources
+                {termData.sampled ? " (sampled)" : ""}
+              </span>
+            )}
+          </div>
+          {termLoading && <div style={{ padding: "1rem", color: "#666", fontSize: "0.85rem" }}>Analyzing codes...</div>}
+          {!termLoading && termData && termData.total_codings === 0 && (
+            <div style={{ padding: "1rem", color: "#666", fontSize: "0.85rem" }}>
+              This resource type carries no coded concepts.
+            </div>
+          )}
+          {!termLoading && termData && termData.total_codings > 0 && (
+            <>
+              <div style={{ display: "flex", alignItems: "center", gap: 14, padding: "0.7rem 0.9rem", borderBottom: "1px solid #f0f0f0", fontSize: "0.8rem", flexWrap: "wrap" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <span style={{ color: "#666" }}>In recognized standards</span>
+                  <div style={{ width: 140, height: 8, background: "#eee", borderRadius: 4, overflow: "hidden" }}>
+                    <div style={{ width: `${Math.round(termData.standard_share * 100)}%`, height: "100%", background: termData.standard_share >= 0.9 ? "#28a745" : termData.standard_share >= 0.5 ? "#ffc107" : "#dc3545" }} />
+                  </div>
+                  <strong style={{ color: "#333" }}>{Math.round(termData.standard_share * 100)}%</strong>
+                </div>
+                <span style={{ color: "#666" }}>
+                  {termData.local_codings.toLocaleString()} local of {termData.total_codings.toLocaleString()} codings
+                </span>
+                {termData.text_only_concepts > 0 && (
+                  <span style={{ color: "#b45309", background: "#fef3c7", borderRadius: 10, padding: "0.1rem 0.5rem" }}>
+                    {termData.text_only_concepts.toLocaleString()} text only, no code
+                  </span>
+                )}
+                {termData.codings_without_system > 0 && (
+                  <span style={{ color: "#b91c1c", background: "#fee2e2", borderRadius: 10, padding: "0.1rem 0.5rem" }}>
+                    {termData.codings_without_system.toLocaleString()} with no system
+                  </span>
+                )}
+              </div>
+              <div style={{ maxHeight: 260, overflowY: "auto" }}>
+                <table style={{ borderCollapse: "collapse", width: "100%", fontSize: "0.8rem" }}>
+                  <thead>
+                    <tr style={{ textAlign: "left", color: "#666" }}>
+                      <th style={{ padding: "0.4rem 0.9rem", fontWeight: 500 }}>System</th>
+                      <th style={{ padding: "0.4rem 0.5rem", fontWeight: 500 }}>Codings</th>
+                      <th style={{ padding: "0.4rem 0.5rem", fontWeight: 500 }}>Distinct</th>
+                      <th style={{ padding: "0.4rem 0.5rem", fontWeight: 500 }}>Used at</th>
+                      <th style={{ padding: "0.4rem 0.9rem", fontWeight: 500 }}>Examples</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {termData.systems.map((s) => (
+                      <tr key={s.system} style={{ borderTop: "1px solid #f0f0f0" }}>
+                        <td style={{ padding: "0.4rem 0.9rem", maxWidth: 280, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={s.uri || s.system}>
+                          <span style={{ display: "inline-block", width: 8, height: 8, borderRadius: "50%", marginRight: 6, background: s.recognized ? "#28a745" : "#dc3545" }} />
+                          <strong style={{ color: "#333" }}>{s.system}</strong>
+                          {!s.recognized && <span style={{ color: "#b91c1c", marginLeft: 6 }}>local</span>}
+                        </td>
+                        <td style={{ padding: "0.4rem 0.5rem", color: "#666" }}>{s.codings.toLocaleString()}</td>
+                        <td style={{ padding: "0.4rem 0.5rem", color: "#666" }}>{s.distinct_codes.toLocaleString()}</td>
+                        <td style={{ padding: "0.4rem 0.5rem", color: "#666", maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{s.paths.join(", ")}</td>
+                        <td style={{ padding: "0.4rem 0.9rem", color: "#94a3b8", maxWidth: 300, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{s.examples.join(", ") || "none"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
           )}
         </div>
       )}

--- a/src/services/sourcesApi.js
+++ b/src/services/sourcesApi.js
@@ -136,6 +136,17 @@ export async function analyzeLinks(sourceId, resourceType, { sample = 20000 } = 
   );
 }
 
+/**
+ * Report which code systems a resource type uses, and how much of its coded
+ * data sits in recognized standards rather than local systems.
+ */
+export async function analyzeTerminology(sourceId, resourceType, { sample = 20000 } = {}) {
+  const qs = new URLSearchParams({ sample: String(sample) });
+  return handle(
+    await fetch(`${SOURCES_BASE}/${sourceId}/resources/${resourceType}/terminology?${qs}`)
+  );
+}
+
 /** Get inferred tabular columns for a resource type. */
 export async function getResourceSchema(sourceId, resourceType, sample = 20) {
   const qs = new URLSearchParams({ sample: String(sample) });


### PR DESCRIPTION
FHIR's value is standardized terminology: data coded in LOINC or SNOMED can be pooled across institutions, the same data in local codes cannot. That difference is invisible in a table of values.

A Codes button now reports what share of a resource type's coded data uses recognized standards (LOINC, SNOMED CT, RxNorm, ICD-9/10, NDC, CVX, UCUM, CPT, HL7), lists every system in use with counts and example codes, and flags three things that block reuse: local or proprietary systems, codings with no system at all, and concepts carrying only free text.

On real MIMIC data this is immediately actionable. Medications come back 0% standard: all 19,689 codings sit in local mimic.mit.edu systems, including one holding NDC codes under a local URI rather than the standard NDC system, so no consumer can recognize them automatically. Microbiology observations come back 67%, where the HL7 category codes are standard but the actual test codes are local, and 293 concepts carry text with no code.

Disk-backed sources analyze a strided sample rather than reading the table into memory.

21 new tests (133 total).
