### PR TITLE
Add patient cohort pivot

### DIFF
--- a/fhir-backend-dynamic/app/routers/sources.py
+++ b/fhir-backend-dynamic/app/routers/sources.py
@@ -157,6 +157,28 @@ async def get_source(source_id: str):
         raise HTTPException(status_code=404, detail="Source not found")
 
 
+@router.get("/{source_id}/cohort")
+async def patient_cohort(
+    source_id: str,
+    sample_per_type: int = Query(20_000, ge=1, le=200_000),
+    limit: int = Query(500, ge=1, le=5000),
+):
+    """Regroup the dataset by patient: one row per patient, counts per type.
+
+    Spans every resource type, since a patient's data is scattered across them.
+    Patients that are only referenced and never present are included and marked,
+    because a cohort built on them would lack demographics.
+    """
+    try:
+        loader = source_registry.get_source(source_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return {
+        "success": True,
+        "data": loader.cohort(sample_per_type=sample_per_type, limit=limit),
+    }
+
+
 @router.get("/{source_id}/resources/{resource_type}")
 async def search_resources(
     source_id: str,

--- a/fhir-backend-dynamic/app/services/sources/base.py
+++ b/fhir-backend-dynamic/app/services/sources/base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 from app.services import schema
+from app.services.sources import cohort as cohort_service
 from app.services.sources import links as links_service
 from app.services.sources import profile as profile_service
 from app.services.sources import terminology as terminology_service
@@ -96,6 +97,24 @@ class SourceLoader(ABC):
             "sampled": len(resources) < total,
             "columns": columns,
         }
+
+    def cohort(self, *, sample_per_type: int = 20_000, limit: int = 500) -> Dict[str, Any]:
+        """Regroup the whole dataset by patient rather than by resource type.
+
+        Unlike the other analyses this spans every resource type, since a
+        patient's data is scattered across them.
+        """
+        def per_type():
+            for resource_type in self.resource_types():
+                yield resource_type, self._sample(resource_type, sample_per_type)
+
+        payload = cohort_service.build_cohort(
+            per_type(),
+            patient_exists=lambda pid: self.read("Patient", pid) is not None,
+            limit=limit,
+        )
+        payload["analyzed_types"] = self.resource_types()
+        return payload
 
     def terminology(self, resource_type: str, *, sample: int = 20_000) -> Dict[str, Any]:
         """Report which code systems this resource type uses.

--- a/fhir-backend-dynamic/app/services/sources/cohort.py
+++ b/fhir-backend-dynamic/app/services/sources/cohort.py
@@ -1,0 +1,101 @@
+"""Pivot a dataset from resources to patients.
+
+Every other view here is resource-oriented: a table of Observations, a table of
+Conditions. Researchers think in patients. A cohort is not "18,000 observations",
+it is "134 patients, and here is how much data each one has".
+
+This regroups resources of every type under the patient they refer to, so one
+row is one patient with a count per resource type. Patients that are only
+referenced, and never present as a Patient resource, are still listed and marked
+absent, because a cohort built on them would silently lack demographics.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+from app.services.sources.links import parse_reference
+
+# Fields that carry the patient a resource is about. FHIR uses ``subject`` on
+# most clinical resources and ``patient`` on a few (AllergyIntolerance,
+# Immunization, and others).
+PATIENT_FIELDS = ("subject", "patient")
+
+
+def extract_patient_id(resource: Dict[str, Any]) -> Optional[str]:
+    """Return the id of the Patient this resource is about, if any.
+
+    Only references that actually point at a Patient count; a ``subject`` that
+    points at a Group or Device is not a patient link.
+    """
+    if not isinstance(resource, dict):
+        return None
+    for field in PATIENT_FIELDS:
+        value = resource.get(field)
+        if isinstance(value, dict) and isinstance(value.get("reference"), str):
+            parsed = parse_reference(value["reference"])
+            if parsed and parsed[0] == "Patient":
+                return parsed[1]
+    return None
+
+
+def build_cohort(
+    resources_by_type: Iterable[Tuple[str, Iterable[Dict[str, Any]]]],
+    *,
+    patient_exists: Callable[[str], bool],
+    limit: int = 500,
+) -> Dict[str, Any]:
+    """Group resources by patient and count them per resource type.
+
+    ``resources_by_type`` yields ``(resource_type, resources)``. Patient
+    resources themselves establish presence; every other type contributes counts
+    against the patient it references.
+    """
+    counts: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    present: set = set()
+    type_names: List[str] = []
+    unlinked: Dict[str, int] = defaultdict(int)
+
+    for resource_type, resources in resources_by_type:
+        if resource_type not in type_names:
+            type_names.append(resource_type)
+        for resource in resources:
+            if resource_type == "Patient":
+                pid = resource.get("id")
+                if isinstance(pid, str) and pid:
+                    present.add(pid)
+                    counts[pid]  # ensure the patient appears even with no data
+                continue
+            pid = extract_patient_id(resource)
+            if pid is None:
+                # Resources not tied to a patient (for example a Medication
+                # definition) are reported separately rather than dropped.
+                unlinked[resource_type] += 1
+                continue
+            counts[pid][resource_type] += 1
+
+    rows = []
+    for pid, per_type in counts.items():
+        total = sum(per_type.values())
+        rows.append({
+            "patient_id": pid,
+            "reference": f"Patient/{pid}",
+            "present": pid in present or patient_exists(pid),
+            "total": total,
+            "counts": dict(per_type),
+        })
+
+    # Richest patients first: those are the ones a cohort can actually use.
+    rows.sort(key=lambda r: (-r["total"], r["patient_id"]))
+
+    linked_types = [t for t in type_names if t != "Patient"]
+    return {
+        "total_patients": len(rows),
+        "patients_present": sum(1 for r in rows if r["present"]),
+        "patients_referenced_only": sum(1 for r in rows if not r["present"]),
+        "resource_types": linked_types,
+        "unlinked": dict(unlinked),
+        "patients": rows[:limit],
+        "truncated": len(rows) > limit,
+    }

--- a/fhir-backend-dynamic/tests/test_sources_cohort.py
+++ b/fhir-backend-dynamic/tests/test_sources_cohort.py
@@ -1,0 +1,159 @@
+"""Tests for the patient cohort pivot."""
+
+import io
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services.sources import cohort as cohort_service
+from app.services.sources import registry as source_registry
+from app.services.sources.local_file import LocalFileSource
+from app.services.sources.store import InMemoryFhirStore
+
+
+# -------------------- extract_patient_id --------------------
+
+def test_extract_from_subject_and_patient_fields():
+    assert cohort_service.extract_patient_id(
+        {"subject": {"reference": "Patient/p1"}}) == "p1"
+    assert cohort_service.extract_patient_id(
+        {"patient": {"reference": "Patient/p2"}}) == "p2"
+
+
+def test_extract_ignores_non_patient_targets():
+    """A subject pointing at a Group is not a patient link."""
+    assert cohort_service.extract_patient_id({"subject": {"reference": "Group/g1"}}) is None
+    assert cohort_service.extract_patient_id({"subject": {"reference": "Device/d1"}}) is None
+
+
+def test_extract_handles_missing_and_malformed():
+    assert cohort_service.extract_patient_id({}) is None
+    assert cohort_service.extract_patient_id({"subject": {}}) is None
+    assert cohort_service.extract_patient_id({"subject": {"reference": "#contained"}}) is None
+    assert cohort_service.extract_patient_id("not a dict") is None
+
+
+# -------------------- build_cohort --------------------
+
+PATIENTS = [{"resourceType": "Patient", "id": "p1"}, {"resourceType": "Patient", "id": "p2"}]
+OBS = [
+    {"resourceType": "Observation", "id": "o1", "subject": {"reference": "Patient/p1"}},
+    {"resourceType": "Observation", "id": "o2", "subject": {"reference": "Patient/p1"}},
+    {"resourceType": "Observation", "id": "o3", "subject": {"reference": "Patient/p2"}},
+    # References a patient that is not in the dataset.
+    {"resourceType": "Observation", "id": "o4", "subject": {"reference": "Patient/ghost"}},
+]
+CONDS = [{"resourceType": "Condition", "id": "c1", "subject": {"reference": "Patient/p1"}}]
+
+
+def _cohort(exists=lambda pid: False, limit=500):
+    return cohort_service.build_cohort(
+        [("Patient", PATIENTS), ("Observation", OBS), ("Condition", CONDS)],
+        patient_exists=exists,
+        limit=limit,
+    )
+
+
+def test_cohort_counts_per_patient_and_type():
+    out = _cohort()
+    rows = {r["patient_id"]: r for r in out["patients"]}
+    assert rows["p1"]["counts"] == {"Observation": 2, "Condition": 1}
+    assert rows["p1"]["total"] == 3
+    assert rows["p2"]["counts"] == {"Observation": 1}
+
+
+def test_cohort_sorts_richest_patient_first():
+    out = _cohort()
+    totals = [r["total"] for r in out["patients"]]
+    assert totals == sorted(totals, reverse=True)
+    assert out["patients"][0]["patient_id"] == "p1"
+
+
+def test_cohort_marks_referenced_only_patients():
+    out = _cohort()
+    rows = {r["patient_id"]: r for r in out["patients"]}
+    assert rows["p1"]["present"] is True
+    assert rows["ghost"]["present"] is False
+    assert out["patients_present"] == 2
+    assert out["patients_referenced_only"] == 1
+
+
+def test_cohort_includes_patients_with_no_clinical_data():
+    """A Patient resource with nothing referencing it still appears."""
+    out = cohort_service.build_cohort(
+        [("Patient", [{"resourceType": "Patient", "id": "lonely"}])],
+        patient_exists=lambda pid: False,
+    )
+    assert out["total_patients"] == 1
+    assert out["patients"][0]["total"] == 0
+
+
+def test_cohort_reports_unlinked_resources():
+    """Resources with no patient link are counted, not silently dropped."""
+    out = cohort_service.build_cohort(
+        [("Medication", [{"resourceType": "Medication", "id": "m1"}])],
+        patient_exists=lambda pid: False,
+    )
+    assert out["unlinked"] == {"Medication": 1}
+    assert out["total_patients"] == 0
+
+
+def test_cohort_respects_limit_and_flags_truncation():
+    many = [
+        {"resourceType": "Observation", "id": f"o{i}", "subject": {"reference": f"Patient/p{i}"}}
+        for i in range(10)
+    ]
+    out = cohort_service.build_cohort(
+        [("Observation", many)], patient_exists=lambda pid: False, limit=3
+    )
+    assert out["total_patients"] == 10
+    assert len(out["patients"]) == 3
+    assert out["truncated"] is True
+
+
+def test_cohort_uses_exists_callback_for_presence():
+    """Presence can also come from the store, not just loaded Patient rows."""
+    out = cohort_service.build_cohort(
+        [("Observation", [OBS[3]])], patient_exists=lambda pid: pid == "ghost"
+    )
+    assert out["patients"][0]["present"] is True
+
+
+# -------------------- loader integration --------------------
+
+def test_loader_cohort():
+    loader = LocalFileSource(InMemoryFhirStore(PATIENTS + OBS + CONDS))
+    out = loader.cohort()
+    assert out["total_patients"] == 3
+    assert set(out["resource_types"]) == {"Observation", "Condition"}
+    assert out["patients"][0]["patient_id"] == "p1"
+
+
+# -------------------- endpoint --------------------
+
+@pytest.fixture
+def client():
+    from app.main import app
+    source_registry.clear()
+    with TestClient(app) as c:
+        yield c
+    source_registry.clear()
+
+
+def test_cohort_endpoint(client):
+    ndjson = "\n".join(json.dumps(r) for r in PATIENTS + OBS + CONDS).encode("utf-8")
+    sid = client.post(
+        "/api/sources/upload",
+        files={"file": ("d.ndjson", io.BytesIO(ndjson), "application/x-ndjson")},
+    ).json()["data"]["source_id"]
+
+    r = client.get(f"/api/sources/{sid}/cohort")
+    assert r.status_code == 200
+    data = r.json()["data"]
+    assert data["total_patients"] == 3
+    assert data["patients_referenced_only"] == 1
+
+
+def test_cohort_endpoint_unknown_source_404(client):
+    assert client.get("/api/sources/nope/cohort").status_code == 404

--- a/src/LocalFileViewer.js
+++ b/src/LocalFileViewer.js
@@ -5,7 +5,7 @@
 // so the table matches the rest of the app.
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { Upload, FileJson, Trash2, X, ArrowLeft, Cloud, Download, BarChart3, Link2 as LinkIcon, Tags } from "lucide-react";
+import { Upload, FileJson, Trash2, X, ArrowLeft, Cloud, Download, BarChart3, Link2 as LinkIcon, Tags, Users } from "lucide-react";
 import { flattenResource, displayValue } from "./api";
 import { readableRow, readableColumns, sortPathFor } from "./fhirDisplay";
 import * as sourcesApi from "./services/sourcesApi";
@@ -50,6 +50,9 @@ function LocalFileViewer() {
   const [termData, setTermData] = useState(null); // code system coverage
   const [termOpen, setTermOpen] = useState(false);
   const [termLoading, setTermLoading] = useState(false);
+  const [cohortData, setCohortData] = useState(null); // patient-level pivot
+  const [cohortOpen, setCohortOpen] = useState(false);
+  const [cohortLoading, setCohortLoading] = useState(false);
 
   // S3 load form state
   const [s3Open, setS3Open] = useState(false);
@@ -232,6 +235,25 @@ function LocalFileViewer() {
     }
   }, [termOpen, termData, source, activeType]);
 
+  // Pivot the dataset to patients. Source level, so it survives type switches.
+  const toggleCohort = useCallback(async () => {
+    if (cohortOpen) {
+      setCohortOpen(false);
+      return;
+    }
+    setCohortOpen(true);
+    if (cohortData || !source) return;
+    setCohortLoading(true);
+    try {
+      setCohortData(await sourcesApi.patientCohort(source.source_id));
+    } catch (e) {
+      setError(e.message);
+      setCohortOpen(false);
+    } finally {
+      setCohortLoading(false);
+    }
+  }, [cohortOpen, cohortData, source]);
+
   // Jump from a reference in the drill-down to the resource it points at.
   const followReference = useCallback(
     async (ref) => {
@@ -313,6 +335,9 @@ function LocalFileViewer() {
     setQuery("");
     setSortField(null);
     setSortOrder("asc");
+    // The cohort describes the whole source, so it only resets on unload.
+    setCohortData(null);
+    setCohortOpen(false);
     if (fileInputRef.current) fileInputRef.current.value = "";
   }, [source]);
 
@@ -527,12 +552,27 @@ function LocalFileViewer() {
               <strong>{source.name}</strong>
               <span style={{ color: "#888" }}>· {source.total} resources · {source.resource_types?.length} types</span>
             </div>
-            <button
-              onClick={handleUnload}
-              style={{ display: "flex", alignItems: "center", gap: 4, background: "#f8f9fa", border: "1px solid #dee2e6", color: "#dc3545", padding: "0.4rem 0.8rem", borderRadius: 4, cursor: "pointer" }}
-            >
-              <Trash2 size={14} /> Unload
-            </button>
+            <div style={{ display: "flex", gap: 6 }}>
+              <button
+                onClick={toggleCohort}
+                title="Regroup the whole dataset by patient"
+                style={{
+                  display: "flex", alignItems: "center", gap: 4, borderRadius: 4, cursor: "pointer", fontSize: "0.85rem",
+                  padding: "0.4rem 0.8rem",
+                  border: cohortOpen ? "1px solid #007bff" : "1px solid #dee2e6",
+                  background: cohortOpen ? "#007bff" : "#f8f9fa",
+                  color: cohortOpen ? "white" : "#555",
+                }}
+              >
+                <Users size={14} /> Patients
+              </button>
+              <button
+                onClick={handleUnload}
+                style={{ display: "flex", alignItems: "center", gap: 4, background: "#f8f9fa", border: "1px solid #dee2e6", color: "#dc3545", padding: "0.4rem 0.8rem", borderRadius: 4, cursor: "pointer" }}
+              >
+                <Trash2 size={14} /> Unload
+              </button>
+            </div>
           </div>
           {preview && (
             <div style={{ background: "#d1e7dd", color: "#0a3622", border: "1px solid #a3cfbb", padding: "0.6rem 0.9rem", borderRadius: 4, marginBottom: "0.75rem", fontSize: "0.85rem" }}>
@@ -757,6 +797,80 @@ function LocalFileViewer() {
                   })}
                 </tbody>
               </table>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Cohort: the dataset seen as patients rather than resources */}
+      {cohortOpen && (
+        <div style={{ border: "1px solid #e0e0e0", borderRadius: 6, marginBottom: "0.75rem", overflow: "hidden" }}>
+          <div style={{ background: "#f8f9fa", padding: "0.6rem 0.9rem", borderBottom: "1px solid #e0e0e0", fontSize: "0.85rem", color: "#333" }}>
+            <strong>Patients</strong>
+            {cohortData && (
+              <span style={{ color: "#888" }}>
+                {" "}{cohortData.total_patients.toLocaleString()} in this dataset
+                {cohortData.patients_referenced_only > 0 && (
+                  <span style={{ color: "#b45309" }}>
+                    {" "}({cohortData.patients_referenced_only.toLocaleString()} referenced but not present)
+                  </span>
+                )}
+              </span>
+            )}
+          </div>
+          {cohortLoading && <div style={{ padding: "1rem", color: "#666", fontSize: "0.85rem" }}>Grouping by patient...</div>}
+          {!cohortLoading && cohortData && cohortData.total_patients === 0 && (
+            <div style={{ padding: "1rem", color: "#666", fontSize: "0.85rem" }}>
+              No resources in this dataset reference a patient.
+              {Object.keys(cohortData.unlinked || {}).length > 0 && (
+                <> Unlinked: {Object.entries(cohortData.unlinked).map(([t, n]) => `${t} (${n.toLocaleString()})`).join(", ")}.</>
+              )}
+            </div>
+          )}
+          {!cohortLoading && cohortData && cohortData.total_patients > 0 && (
+            <div style={{ maxHeight: 320, overflowY: "auto" }}>
+              <table style={{ borderCollapse: "collapse", width: "100%", fontSize: "0.8rem" }}>
+                <thead>
+                  <tr style={{ textAlign: "left", color: "#666" }}>
+                    <th style={{ padding: "0.4rem 0.9rem", fontWeight: 500 }}>Patient</th>
+                    <th style={{ padding: "0.4rem 0.5rem", fontWeight: 500 }}>Total</th>
+                    {cohortData.resource_types.map((t) => (
+                      <th key={t} style={{ padding: "0.4rem 0.5rem", fontWeight: 500 }}>{t}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {cohortData.patients.map((p) => (
+                    <tr
+                      key={p.patient_id}
+                      onClick={() => p.present && followReference(p.reference)}
+                      style={{ borderTop: "1px solid #f0f0f0", cursor: p.present ? "pointer" : "default" }}
+                      onMouseEnter={(e) => p.present && (e.currentTarget.style.background = "#f6faff")}
+                      onMouseLeave={(e) => (e.currentTarget.style.background = "white")}
+                    >
+                      <td style={{ padding: "0.4rem 0.9rem", whiteSpace: "nowrap", maxWidth: 320, overflow: "hidden", textOverflow: "ellipsis" }}>
+                        <span style={{ color: p.present ? "#1d4ed8" : "#94a3b8" }}>{p.reference}</span>
+                        {!p.present && (
+                          <span style={{ marginLeft: 6, color: "#b45309", background: "#fef3c7", borderRadius: 8, padding: "0 0.4rem" }}>
+                            not in file
+                          </span>
+                        )}
+                      </td>
+                      <td style={{ padding: "0.4rem 0.5rem", color: "#333", fontWeight: 500 }}>{p.total.toLocaleString()}</td>
+                      {cohortData.resource_types.map((t) => (
+                        <td key={t} style={{ padding: "0.4rem 0.5rem", color: p.counts[t] ? "#666" : "#ddd" }}>
+                          {(p.counts[t] || 0).toLocaleString()}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {cohortData.truncated && (
+                <div style={{ padding: "0.5rem 0.9rem", color: "#888", fontSize: "0.75rem", borderTop: "1px solid #f0f0f0" }}>
+                  Showing the first {cohortData.patients.length.toLocaleString()} patients by data volume.
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/services/sourcesApi.js
+++ b/src/services/sourcesApi.js
@@ -147,6 +147,18 @@ export async function analyzeTerminology(sourceId, resourceType, { sample = 2000
   );
 }
 
+/**
+ * Regroup the whole dataset by patient: one row per patient with counts per
+ * resource type. Spans every resource type, so it is source level.
+ */
+export async function patientCohort(sourceId, { samplePerType = 20000, limit = 500 } = {}) {
+  const qs = new URLSearchParams({
+    sample_per_type: String(samplePerType),
+    limit: String(limit),
+  });
+  return handle(await fetch(`${SOURCES_BASE}/${sourceId}/cohort?${qs}`));
+}
+
 /** Get inferred tabular columns for a resource type. */
 export async function getResourceSchema(sourceId, resourceType, sample = 20) {
   const qs = new URLSearchParams({ sample: String(sample) });


### PR DESCRIPTION
Every other view here is resource-oriented: a table of Observations, a table of Conditions. Researchers think in patients. A cohort is not "18,000 observations", it is "134 patients, and here is how much data each one has".

A Patients button now regroups the whole dataset by the patient each resource refers to: one row per patient, a count per resource type, ranked by data volume. Present patients open in the drill-down; patients that are only referenced and never appear as a Patient resource are listed and marked, because a cohort built on them would silently lack demographics.

On a MIMIC microbiology slice, 3,000 observations collapse to 134 patients ranked from 153 down to 75 observations each, all flagged as absent since that export contains only Observations.

Only references that actually point at a Patient count, so a subject pointing at a Group or Device is not treated as a patient link. Resources with no patient link at all are reported separately rather than dropped.

13 new tests (146 total).
